### PR TITLE
✨ add native support for `sx` and `sxdg` gates to qasm parser

### DIFF
--- a/include/parsers/qasm_parser/Parser.hpp
+++ b/include/parsers/qasm_parser/Parser.hpp
@@ -103,22 +103,6 @@ namespace qasm {
             virtual ~BasisGate() = default;
         };
 
-        struct Ugate: public BasisGate {
-            Expr*       theta  = nullptr;
-            Expr*       phi    = nullptr;
-            Expr*       lambda = nullptr;
-            std::string target;
-
-            Ugate(Expr* theta, Expr* phi, Expr* lambda, std::string target):
-                theta(theta), phi(phi), lambda(lambda), target(std::move(target)) {}
-
-            ~Ugate() override {
-                delete theta;
-                delete phi;
-                delete lambda;
-            }
-        };
-
         struct CUgate: public BasisGate {
             Expr*                    theta  = nullptr;
             Expr*                    phi    = nullptr;
@@ -142,6 +126,22 @@ namespace qasm {
 
             CXgate(std::string control, std::string target):
                 control(std::move(control)), target(std::move(target)) {}
+        };
+
+        struct SingleQubitGate: public BasisGate {
+            std::string target;
+            qc::OpType  type;
+            Expr*       lambda;
+            Expr*       phi;
+            Expr*       theta;
+
+            explicit SingleQubitGate(std::string target, qc::OpType type = qc::U3, Expr* lambda = nullptr, Expr* phi = nullptr, Expr* theta = nullptr):
+                target(std::move(target)), type(type), lambda(lambda), phi(phi), theta(theta) {}
+            ~SingleQubitGate() override {
+                delete lambda;
+                delete phi;
+                delete theta;
+            }
         };
 
         struct SWAPgate: public BasisGate {

--- a/include/parsers/qasm_parser/Token.hpp
+++ b/include/parsers/qasm_parser/Token.hpp
@@ -62,6 +62,8 @@ namespace qasm {
             mcx_recursive,
             mcx_vchain,
             mcphase,
+            sxgate,
+            sxdggate,
             comment
         };
 
@@ -106,6 +108,8 @@ namespace qasm {
             {Token::Kind::mcx_recursive, "mcx_recursive"},
             {Token::Kind::mcx_vchain, "mcx_vchain"},
             {Token::Kind::mcphase, "mcphase"},
+            {Token::Kind::sxgate, "sx"},
+            {Token::Kind::sxdggate, "sxdg"},
             {Token::Kind::pi, "pi"},
             {Token::Kind::measure, "measure"},
             {Token::Kind::openqasm, "openqasm"},

--- a/src/parsers/QASMParser.cpp
+++ b/src/parsers/QASMParser.cpp
@@ -38,7 +38,7 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
             p.check(Token::Kind::semicolon);
             addClassicalRegister(n, s.c_str());
             p.nclassics = nclassics;
-        } else if (p.sym == Token::Kind::ugate || p.sym == Token::Kind::cxgate || p.sym == Token::Kind::swap || p.sym == Token::Kind::identifier || p.sym == Token::Kind::measure || p.sym == Token::Kind::reset || p.sym == Token::Kind::mcx_gray || p.sym == Token::Kind::mcx_recursive || p.sym == Token::Kind::mcx_vchain || p.sym == Token::Kind::mcphase) {
+        } else if (p.sym == Token::Kind::ugate || p.sym == Token::Kind::cxgate || p.sym == Token::Kind::swap || p.sym == Token::Kind::identifier || p.sym == Token::Kind::measure || p.sym == Token::Kind::reset || p.sym == Token::Kind::mcx_gray || p.sym == Token::Kind::mcx_recursive || p.sym == Token::Kind::mcx_vchain || p.sym == Token::Kind::mcphase || p.sym == Token::Kind::sxgate || p.sym == Token::Kind::sxdggate) {
             ops.emplace_back(p.Qop());
         } else if (p.sym == Token::Kind::gate) {
             p.GateDecl();

--- a/src/parsers/qasm_parser/Parser.cpp
+++ b/src/parsers/qasm_parser/Parser.cpp
@@ -729,7 +729,10 @@ namespace qasm {
                         std::unique_ptr<Expr> lambda(RewriteExpr(u->lambda, paramMap));
 
                         if (argMap.at(u->target).second == 1) {
-                            op.emplace_back<qc::StandardOperation>(nqubits, argMap.at(u->target).first, qc::U3, lambda->num, phi->num, theta->num);
+                            op.emplace_back<qc::StandardOperation>(nqubits, argMap.at(u->target).first, u->type,
+                                                                   lambda ? lambda->num : 0.,
+                                                                   phi ? phi->num : 0.,
+                                                                   theta ? theta->num : 0.);
                         } else {
                             // TODO: multiple targets could be useful here
                             for (dd::QubitCount j = 0; j < argMap.at(u->target).second; ++j) {

--- a/src/parsers/qasm_parser/Parser.cpp
+++ b/src/parsers/qasm_parser/Parser.cpp
@@ -523,6 +523,23 @@ namespace qasm {
                 return std::make_unique<qc::CompoundOperation>(std::move(gate));
             }
 
+        } else if (sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
+            const auto type = (sym == Token::Kind::sxgate) ? qc::SX : qc::SXdag;
+            scan();
+
+            auto target = ArgumentQreg();
+            check(Token::Kind::semicolon);
+
+            if (target.second == 1) {
+                return std::make_unique<qc::StandardOperation>(nqubits, target.first, type);
+            }
+
+            // TODO: multiple targets could be useful here
+            auto gate = qc::CompoundOperation(nqubits);
+            for (dd::QubitCount i = 0; i < target.second; ++i) {
+                gate.emplace_back<qc::StandardOperation>(nqubits, static_cast<dd::Qubit>(target.first + i), type);
+            }
+            return std::make_unique<qc::CompoundOperation>(std::move(gate));
         } else if (sym == Token::Kind::identifier) {
             scan();
             auto           gateName  = t.str;
@@ -672,7 +689,7 @@ namespace qasm {
                         for (size_t j = 0; j < parameters.size(); ++j)
                             paramMap[cGateIt->second.parameterNames[j]] = parameters[j];
 
-                        if (auto cu = dynamic_cast<Ugate*>(cGate)) {
+                        if (auto cu = dynamic_cast<SingleQubitGate*>(cGate)) {
                             std::unique_ptr<Expr> theta(RewriteExpr(cu->theta, paramMap));
                             std::unique_ptr<Expr> phi(RewriteExpr(cu->phi, paramMap));
                             std::unique_ptr<Expr> lambda(RewriteExpr(cu->lambda, paramMap));
@@ -689,7 +706,7 @@ namespace qasm {
                 // identifier specifies just a single operation (U3 or CX)
                 if (gateIt != compoundGates.end() && gateIt->second.gates.size() == 1) {
                     auto gate = gateIt->second.gates.front();
-                    if (auto u = dynamic_cast<Ugate*>(gate)) {
+                    if (auto u = dynamic_cast<SingleQubitGate*>(gate)) {
                         std::unique_ptr<Expr> theta(RewriteExpr(u->theta, paramMap));
                         std::unique_ptr<Expr> phi(RewriteExpr(u->phi, paramMap));
                         std::unique_ptr<Expr> lambda(RewriteExpr(u->lambda, paramMap));
@@ -706,7 +723,7 @@ namespace qasm {
 
                 qc::CompoundOperation op(nqubits);
                 for (auto& gate: gateIt->second.gates) {
-                    if (auto u = dynamic_cast<Ugate*>(gate)) {
+                    if (auto u = dynamic_cast<SingleQubitGate*>(gate)) {
                         std::unique_ptr<Expr> theta(RewriteExpr(u->theta, paramMap));
                         std::unique_ptr<Expr> phi(RewriteExpr(u->phi, paramMap));
                         std::unique_ptr<Expr> lambda(RewriteExpr(u->lambda, paramMap));
@@ -861,7 +878,7 @@ namespace qasm {
     void Parser::GateDecl() {
         check(Token::Kind::gate);
         // skip declarations of known gates
-        if (sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase || sym == Token::Kind::swap) {
+        if (sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase || sym == Token::Kind::swap || sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
             while (sym != Token::Kind::rbrace)
                 scan();
 
@@ -909,7 +926,13 @@ namespace qasm {
                 check(Token::Kind::rpar);
                 check(Token::Kind::identifier);
 
-                gate.gates.push_back(new Ugate(theta, phi, lambda, t.str));
+                gate.gates.push_back(new SingleQubitGate(t.str, qc::U3, lambda, phi, theta));
+                check(Token::Kind::semicolon);
+            } else if (sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
+                const auto gateType = sym == Token::Kind::sxgate ? qc::SX : qc::SXdag;
+                scan();
+                check(Token::Kind::identifier);
+                gate.gates.push_back(new SingleQubitGate(t.str, gateType));
                 check(Token::Kind::semicolon);
             } else if (sym == Token::Kind::cxgate) {
                 scan();
@@ -1024,8 +1047,8 @@ namespace qasm {
                             paramMap[gateIt->second.parameterNames[i]] = parameters[i];
 
                         for (auto& it: gateIt->second.gates) {
-                            if (auto u = dynamic_cast<Ugate*>(it)) {
-                                gate.gates.push_back(new Ugate(RewriteExpr(u->theta, paramMap), RewriteExpr(u->phi, paramMap), RewriteExpr(u->lambda, paramMap), argMap.at(u->target)));
+                            if (auto u = dynamic_cast<SingleQubitGate*>(it)) {
+                                gate.gates.push_back(new SingleQubitGate(argMap.at(u->target), u->type, RewriteExpr(u->lambda, paramMap), RewriteExpr(u->phi, paramMap), RewriteExpr(u->theta, paramMap)));
                             } else if (auto cx = dynamic_cast<CXgate*>(it)) {
                                 gate.gates.push_back(new CXgate(argMap.at(cx->control), argMap.at(cx->target)));
                             } else if (auto cu = dynamic_cast<CUgate*>(it)) {
@@ -1079,7 +1102,7 @@ namespace qasm {
                             std::vector<std::string> controls{};
                             for (size_t i = 0; i < arguments.size() - 1; ++i)
                                 controls.emplace_back(arguments[i]);
-                            if (auto u = dynamic_cast<Ugate*>(cGateIt->second.gates.at(0))) {
+                            if (auto u = dynamic_cast<SingleQubitGate*>(cGateIt->second.gates.at(0))) {
                                 gate.gates.push_back(new CUgate(RewriteExpr(u->theta, paramMap), RewriteExpr(u->phi, paramMap), RewriteExpr(u->lambda, paramMap), controls, arguments.back()));
                             } else {
                                 throw QASMParserException("Could not cast to UGate in gate declaration.");
@@ -1112,6 +1135,7 @@ namespace qasm {
     std::unique_ptr<qc::Operation> Parser::Qop() {
         if (sym == Token::Kind::ugate || sym == Token::Kind::cxgate ||
             sym == Token::Kind::swap || sym == Token::Kind::identifier ||
+            sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate ||
             sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase)
             return Gate();
         else if (sym == Token::Kind::measure) {

--- a/src/parsers/qasm_parser/Scanner.cpp
+++ b/src/parsers/qasm_parser/Scanner.cpp
@@ -124,6 +124,8 @@ namespace qasm {
         keywords["mcx_recursive"]      = Token::Kind::mcx_recursive;
         keywords["mcx_vchain"]         = Token::Kind::mcx_vchain;
         keywords["mcphase"]            = Token::Kind::mcphase;
+        keywords["sx"]                 = Token::Kind::sxgate;
+        keywords["sxdg"]               = Token::Kind::sxdggate;
         keywords["pi"]                 = Token::Kind::pi;
         keywords["OPENQASM"]           = Token::Kind::openqasm;
         keywords["show_probabilities"] = Token::Kind::probabilities;

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -378,3 +378,29 @@ TEST_F(IO, printing_non_unitary) {
         std::cout << std::endl;
     }
 }
+
+TEST_F(IO, sx_and_sxdag) {
+    std::stringstream ss{};
+    ss << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[1];"
+       << "creg c[1];"
+       << "gate test q0 { sx q0; sxdg q0;}"
+       << "sx q[0];"
+       << "sxdg q[0];"
+       << "test q[0];"
+       << std::endl;
+    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM));
+    std::cout << *qc << std::endl;
+    auto& op1 = *(qc->begin());
+    EXPECT_EQ(op1->getType(), qc::OpType::SX);
+    auto& op2 = *(++qc->begin());
+    EXPECT_EQ(op2->getType(), qc::OpType::SXdag);
+    auto& op3 = *(++(++qc->begin()));
+    ASSERT_TRUE(op3->isCompoundOperation());
+    auto  compOp  = dynamic_cast<qc::CompoundOperation*>(op3.get());
+    auto& compOp1 = *(compOp->begin());
+    EXPECT_EQ(compOp1->getType(), qc::OpType::SX);
+    auto& compOp2 = *(++compOp->begin());
+    EXPECT_EQ(compOp2->getType(), qc::OpType::SXdag);
+}


### PR DESCRIPTION
Up until now, reading a `.qasm` file that contains a `sx` or `sxdg` gate results in a `QuantumComputation` with a `CompoundOperation` that contains the decomposed gate sequence for these gates (e.g., `sdg - h - sdg` for `sx`).
This PR adds native support for these gates to the QFR `.qasm` parser.
As a result, `.qasm` files featuring these gates can be handled more directly.