### PR TITLE
✨ Measurements from output permutation

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -373,6 +373,8 @@ namespace qc {
         }
         void import(std::istream&& is, Format format);
         void initializeIOMapping();
+        // append measurements to the end of the circuit according to the tracked output permutation
+        void appendMeasurementsAccordingToOutputPermutation(const std::string& registerName = DEFAULT_CREG);
         // search for current position of target value in map and afterwards exchange it with the value at new position
         static void findAndSWAP(dd::Qubit targetValue, dd::Qubit newPosition, Permutation& map) {
             for (const auto& q: map) {
@@ -387,8 +389,10 @@ namespace qc {
         void addQubitRegister(std::size_t, const char* reg_name = DEFAULT_QREG);
         void addClassicalRegister(std::size_t nc, const char* reg_name = DEFAULT_CREG);
         void addAncillaryRegister(std::size_t nq, const char* reg_name = DEFAULT_ANCREG);
+        // a function to combine all quantum registers (qregs and ancregs) into a single register (useful for circuits mapped to a device)
+        void unifyQuantumRegisters(const std::string& regName = DEFAULT_QREG);
 
-        // removes the a specific logical qubit and returns the index of the physical qubit in the initial layout
+        // removes a specific logical qubit and returns the index of the physical qubit in the initial layout
         // as well as the index of the removed physical qubit's output permutation
         // i.e., initialLayout[physical_qubit] = logical_qubit and outputPermutation[physicalQubit] = output_qubit
         std::pair<dd::Qubit, dd::Qubit> removeQubit(dd::Qubit logical_qubit_index);

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -966,4 +966,32 @@ namespace qc {
         }
         return true;
     }
+
+    void QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
+        ancregs.clear();
+        qregs.clear();
+        qregs[regName] = {0, getNqubits()};
+    }
+
+    void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(const std::string& registerName) {
+        // ensure that the circuit contains enough classical registers
+        if (cregs.empty()) {
+            // in case there are no registers, create a new one
+            addClassicalRegister(nqubits, registerName.c_str());
+        } else if (nclassics < outputPermutation.size()) {
+            if (cregs.find(registerName) == cregs.end()) {
+                // in case there are registers but not enough, add a new one
+                addClassicalRegister(outputPermutation.size() - nclassics, registerName.c_str());
+            } else {
+                // in case the register already exists, augment it
+                nclassics += outputPermutation.size() - nclassics;
+                cregs[registerName].second = outputPermutation.size();
+            }
+        }
+
+        // append measurements according to output permutation
+        for (const auto& [qubit, clbit]: outputPermutation) {
+            measure(qubit, clbit);
+        }
+    }
 } // namespace qc

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -404,3 +404,135 @@ TEST_F(IO, sx_and_sxdag) {
     auto& compOp2 = *(++compOp->begin());
     EXPECT_EQ(compOp2->getType(), qc::OpType::SXdag);
 }
+
+TEST_F(IO, unify_registers) {
+    std::stringstream ss{};
+    ss << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[1];"
+       << "qreg r[1];"
+       << "x q[0];"
+       << "x r[0];"
+       << std::endl;
+    qc->import(ss, qc::OpenQASM);
+    std::cout << *qc << std::endl;
+    qc->unifyQuantumRegisters();
+    std::cout << *qc << std::endl;
+    std::ostringstream oss{};
+    qc->dump(oss, qc::OpenQASM);
+    EXPECT_STREQ(oss.str().c_str(),
+                 "// i 0 1\n"
+                 "// o 0 1\n"
+                 "OPENQASM 2.0;\n"
+                 "include \"qelib1.inc\";\n"
+                 "qreg q[2];\n"
+                 "x q[0];\n"
+                 "x q[1];\n");
+}
+
+TEST_F(IO, append_measurements_according_to_output_permutation) {
+    std::stringstream ss{};
+    ss << "// o 1\n"
+       << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[2];"
+       << "x q[1];"
+       << std::endl;
+    qc->import(ss, qc::OpenQASM);
+    qc->appendMeasurementsAccordingToOutputPermutation();
+    std::cout << *qc << std::endl;
+    const auto& op = *(qc->rbegin());
+    ASSERT_EQ(op->getType(), qc::OpType::Measure);
+    const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
+    EXPECT_EQ(meas->getTargets().size(), 1U);
+    EXPECT_EQ(meas->getTargets().front(), 1U);
+    EXPECT_EQ(meas->getClassics().size(), 1U);
+    EXPECT_EQ(meas->getClassics().front(), 0U);
+}
+
+TEST_F(IO, append_measurements_according_to_output_permutation_augment_register) {
+    std::stringstream ss{};
+    ss << "// o 0 1\n"
+       << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[2];"
+       << "creg c[1];"
+       << "x q;"
+       << std::endl;
+    qc->import(ss, qc::OpenQASM);
+    qc->appendMeasurementsAccordingToOutputPermutation();
+    std::cout << *qc << std::endl;
+    EXPECT_EQ(qc->getNcbits(), 2U);
+    const auto& op = *(qc->rbegin());
+    ASSERT_EQ(op->getType(), qc::OpType::Measure);
+    const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
+    EXPECT_EQ(meas->getTargets().size(), 1U);
+    EXPECT_EQ(meas->getTargets().front(), 1U);
+    EXPECT_EQ(meas->getClassics().size(), 1U);
+    EXPECT_EQ(meas->getClassics().front(), 1U);
+    const auto& op2 = *(++qc->rbegin());
+    ASSERT_EQ(op2->getType(), qc::OpType::Measure);
+    const auto& meas2 = dynamic_cast<const qc::NonUnitaryOperation*>(op2.get());
+    EXPECT_EQ(meas2->getTargets().size(), 1U);
+    EXPECT_EQ(meas2->getTargets().front(), 0U);
+    EXPECT_EQ(meas2->getClassics().size(), 1U);
+    EXPECT_EQ(meas2->getClassics().front(), 0U);
+    std::ostringstream oss{};
+    qc->dump(oss, qc::OpenQASM);
+    std::cout << oss.str() << std::endl;
+    EXPECT_STREQ(oss.str().c_str(),
+                 "// i 0 1\n"
+                 "// o 0 1\n"
+                 "OPENQASM 2.0;\n"
+                 "include \"qelib1.inc\";\n"
+                 "qreg q[2];\n"
+                 "creg c[2];\n"
+                 "x q[0];\n"
+                 "x q[1];\n"
+                 "measure q[0] -> c[0];\n"
+                 "measure q[1] -> c[1];\n");
+}
+
+TEST_F(IO, append_measurements_according_to_output_permutation_add_register) {
+    std::stringstream ss{};
+    ss << "// o 0 1\n"
+       << "OPENQASM 2.0;"
+       << "include \"qelib1.inc\";"
+       << "qreg q[2];"
+       << "creg d[1];"
+       << "x q;"
+       << std::endl;
+    qc->import(ss, qc::OpenQASM);
+    qc->appendMeasurementsAccordingToOutputPermutation();
+    std::cout << *qc << std::endl;
+    EXPECT_EQ(qc->getNcbits(), 2U);
+    const auto& op = *(qc->rbegin());
+    ASSERT_EQ(op->getType(), qc::OpType::Measure);
+    const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
+    EXPECT_EQ(meas->getTargets().size(), 1U);
+    EXPECT_EQ(meas->getTargets().front(), 1U);
+    EXPECT_EQ(meas->getClassics().size(), 1U);
+    EXPECT_EQ(meas->getClassics().front(), 1U);
+    const auto& op2 = *(++qc->rbegin());
+    ASSERT_EQ(op2->getType(), qc::OpType::Measure);
+    const auto& meas2 = dynamic_cast<const qc::NonUnitaryOperation*>(op2.get());
+    EXPECT_EQ(meas2->getTargets().size(), 1U);
+    EXPECT_EQ(meas2->getTargets().front(), 0U);
+    EXPECT_EQ(meas2->getClassics().size(), 1U);
+    EXPECT_EQ(meas2->getClassics().front(), 0U);
+    std::ostringstream oss{};
+    qc->dump(oss, qc::OpenQASM);
+    std::cout << oss.str() << std::endl;
+    EXPECT_STREQ(oss.str().c_str(),
+                 "// i 0 1\n"
+                 "// o 0 1\n"
+                 "OPENQASM 2.0;\n"
+                 "include \"qelib1.inc\";\n"
+                 "qreg q[2];\n"
+                 "creg d[1];\n"
+                 "creg c[1];\n"
+                 "x q[0];\n"
+                 "x q[1];\n"
+                 "measure q[0] -> d[0];\n"
+                 "measure q[1] -> c[0];\n");
+}


### PR DESCRIPTION
This PR adds the functionality to add measurements according to the output permutation of a quantum circuit.
This is a first step towards realizing #35, in that it correctly conveys the expected output permutation in a standardized fashion.

Furthermore, this PR adds a convenience function to unify all quantum registers of a quantum circuit into a single register, which is useful for mapped circuits.