### PR TITLE
✨ CNOT Cancellation Optimisation Pass

### DIFF
--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -51,6 +51,8 @@ namespace qc {
 
         static void flattenOperations(QuantumComputation& qc);
 
+        static void cancelCNOTs(QuantumComputation& qc);
+
     protected:
         static void removeDiagonalGatesBeforeMeasureRecursive(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, const DAGReverseIterator& until);
         static bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, DAGReverseIterator& it, qc::Operation* op);

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -500,5 +500,6 @@ namespace qc {
 
         [[nodiscard]] const auto& at(std::size_t i) const { return ops.at(i); }
         [[nodiscard]] const auto& front() const { return ops.front(); }
+        [[nodiscard]] const auto& back() const { return ops.back(); }
     };
 } // namespace qc

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1700,3 +1700,71 @@ TEST_F(QFRFunctionality, OperationEquality) {
     EXPECT_FALSE(compound0.equals(compound1));
     EXPECT_FALSE(compound0.equals(compound2));
 }
+
+TEST_F(QFRFunctionality, CNOTCancellation1) {
+    QuantumComputation qc(2);
+    qc.x(0, 1_pc);
+    qc.x(0, 1_pc);
+
+    CircuitOptimizer::cancelCNOTs(qc);
+    EXPECT_TRUE(qc.empty());
+}
+
+TEST_F(QFRFunctionality, CNOTCancellation2) {
+    QuantumComputation qc(2);
+    qc.swap(0, 1);
+    qc.swap(0, 1);
+
+    CircuitOptimizer::cancelCNOTs(qc);
+    EXPECT_TRUE(qc.empty());
+}
+
+TEST_F(QFRFunctionality, CNOTCancellation3) {
+    QuantumComputation qc(2);
+    qc.swap(0, 1);
+    qc.x(0, 1_pc);
+
+    CircuitOptimizer::cancelCNOTs(qc);
+    EXPECT_TRUE(qc.size() == 2U);
+    auto& firstOperation = qc.front();
+    EXPECT_EQ(firstOperation->getType(), qc::X);
+    EXPECT_EQ(firstOperation->getTargets().front(), 0U);
+    EXPECT_EQ(firstOperation->getControls().begin()->qubit, 1U);
+
+    auto& secondOperation = qc.back();
+    EXPECT_EQ(secondOperation->getType(), qc::X);
+    EXPECT_EQ(secondOperation->getTargets().front(), 1U);
+    EXPECT_EQ(secondOperation->getControls().begin()->qubit, 0U);
+}
+
+TEST_F(QFRFunctionality, CNOTCancellation4) {
+    QuantumComputation qc(2);
+    qc.x(0, 1_pc);
+    qc.swap(0, 1);
+
+    CircuitOptimizer::cancelCNOTs(qc);
+    EXPECT_TRUE(qc.size() == 2U);
+    auto& firstOperation = qc.front();
+    EXPECT_EQ(firstOperation->getType(), qc::X);
+    EXPECT_EQ(firstOperation->getTargets().front(), 1U);
+    EXPECT_EQ(firstOperation->getControls().begin()->qubit, 0U);
+
+    auto& secondOperation = qc.back();
+    EXPECT_EQ(secondOperation->getType(), qc::X);
+    EXPECT_EQ(secondOperation->getTargets().front(), 0U);
+    EXPECT_EQ(secondOperation->getControls().begin()->qubit, 1U);
+}
+
+TEST_F(QFRFunctionality, CNOTCancellation5) {
+    QuantumComputation qc(2);
+    qc.x(0, 1_pc);
+    qc.x(1, 0_pc);
+    qc.x(0, 1_pc);
+
+    CircuitOptimizer::cancelCNOTs(qc);
+    EXPECT_TRUE(qc.size() == 1U);
+    auto& firstOperation = qc.front();
+    EXPECT_EQ(firstOperation->getType(), qc::SWAP);
+    EXPECT_EQ(firstOperation->getTargets().front(), 0U);
+    EXPECT_EQ(firstOperation->getTargets().back(), 1U);
+}


### PR DESCRIPTION
This PR adds a new optimization method to the QFR library which allows to cancel adjacent CNOT gates.