### PR TITLE
Make Usage of Single Header JSON Lib Explicit

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC MQT::DDPackage)
 
 # add nlohmann::json library
 set(JSON_BuildTests OFF CACHE INTERNAL "")
+set(JSON_MultipleHeaders OFF CACHE INTERNAL "")
 add_subdirectory("${PROJECT_SOURCE_DIR}/extern/json" "extern/json" EXCLUDE_FROM_ALL)
 target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
 


### PR DESCRIPTION
Fixes #124 by explicitly requesting the single header version of the nlohmann/json library.