### PR TITLE
🐛 Fix for Qiskit `Layout` import

### DIFF
--- a/mqt/qfr/qiskit/QuantumCircuit.hpp
+++ b/mqt/qfr/qiskit/QuantumCircuit.hpp
@@ -282,7 +282,7 @@ namespace qc::qiskit {
             py::dict logicalQubitIndices{};
 
             // the ancilla register
-            decltype(registers.get_type()) ancillaRegister{};
+            decltype(registers.get_type()) ancillaRegister = py::none();
 
             for (const auto qreg: registers) {
                 const auto qregName = qreg.attr("name").cast<std::string>();


### PR DESCRIPTION
This PR fixes a bug in the import of initial layout information from Qiskit that results in a segfault when trying to import a circuit containing layout information but not containing an ancillary register.