### PR TITLE
🐛 Fix bug in `cancelCNOTs` optimization

### DIFF
--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1207,7 +1207,7 @@ namespace qc {
 
             if (isSWAP && prevOpIsSWAP) {
                 // two identical SWAP gates cancel each other
-                if (q0 == prevQ0 && q1 == prevQ1) {
+                if (std::set{q0, q1} == std::set{prevQ0, prevQ1}) {
                     dag.at(q0).pop_back();
                     dag.at(q1).pop_back();
                     op0->setGate(I);
@@ -1233,11 +1233,11 @@ namespace qc {
 
             if (isSWAP && prevOpIsCNOT) {
                 // CNOT followed by a SWAP is equivalent to two CNOTs
-                op0->setControls({dd::Control{q0}});
-                op0->setTargets({q1});
+                op0->setControls({dd::Control{prevQ0}});
+                op0->setTargets({prevQ1});
                 it->setGate(X);
-                it->setControls({dd::Control{q1}});
-                it->setTargets({q0});
+                it->setControls({dd::Control{prevQ1}});
+                it->setTargets({prevQ0});
                 addToDag(dag, &it);
                 continue;
             }

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1713,7 +1713,7 @@ TEST_F(QFRFunctionality, CNOTCancellation1) {
 TEST_F(QFRFunctionality, CNOTCancellation2) {
     QuantumComputation qc(2);
     qc.swap(0, 1);
-    qc.swap(0, 1);
+    qc.swap(1, 0);
 
     CircuitOptimizer::cancelCNOTs(qc);
     EXPECT_TRUE(qc.empty());


### PR DESCRIPTION
This PR fixes a rare bug in the `cancelCNOTs` optimization that popped up in QMAP when a CNOT is followed by a SWAP and the SWAP's targets are not in sorted order. This resulted in an incorrect substitution of CNOTs.