### PR TITLE
✨ support `reset` operations in Qiskit circuit import

### DIFF
--- a/mqt/qfr/qiskit/QasmQobjExperiment.hpp
+++ b/mqt/qfr/qiskit/QasmQobjExperiment.hpp
@@ -68,6 +68,13 @@ namespace qc::qiskit {
                     targets.emplace_back(target);
                 }
                 qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), targets, Barrier);
+            } else if (instructionName == "reset") {
+                Targets targets{};
+                for (const auto qubit: instruction.attr("qubits")) {
+                    auto target = qubit.cast<dd::Qubit>();
+                    targets.emplace_back(target);
+                }
+                qc.reset(targets);
             } else if (nativelySupportedGates.count(instructionName)) {
                 auto&&   qubits = instruction.attr("qubits").cast<py::list>();
                 py::list params{};

--- a/mqt/qfr/qiskit/QuantumCircuit.hpp
+++ b/mqt/qfr/qiskit/QuantumCircuit.hpp
@@ -117,6 +117,13 @@ namespace qc::qiskit {
                     targets.emplace_back(target);
                 }
                 qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), targets, Barrier);
+            } else if (instructionName == "reset") {
+                Targets targets{};
+                for (const auto qubit: qargs) {
+                    auto target = qubitMap[qubit].cast<dd::Qubit>();
+                    targets.emplace_back(target);
+                }
+                qc.reset(targets);
             } else if (nativelySupportedGates.count(instructionName)) {
                 // natively supported operations
                 if (instructionName == "i" || instructionName == "id" || instructionName == "iden") {


### PR DESCRIPTION
As of now, `reset` operations were not supported by the Qiskit circuit import. This PR adds the corresponding functionality.