### PR TITLE
🐛 Fix dynamic circuit transformation

### DIFF
--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -705,8 +705,6 @@ namespace qc {
             for (auto& op: qc.ops) {
                 op->setNqubits(qc.getNqubits());
             }
-            qc.outputPermutation.clear();
-            qc.initializeIOMapping();
         }
     }
 

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -705,6 +705,8 @@ namespace qc {
             for (auto& op: qc.ops) {
                 op->setNqubits(qc.getNqubits());
             }
+            qc.outputPermutation.clear();
+            qc.initializeIOMapping();
         }
     }
 

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -770,7 +770,7 @@ namespace qc {
                 // iterate over all subsequent operations
                 while (opIt != qc.end()) {
                     const auto operation = opIt->get();
-                    if (operation->isUnitary()) {
+                    if (operation->isUnitary() || operation->getType() == qc::Barrier) {
                         // if an operation does not act on the measured qubit, the insert location for potential operations has to be updated
                         if (!operation->actsOn(targets.at(0))) {
                             ++currentInsertionPoint;

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -104,20 +104,21 @@ namespace qc {
 
         for (auto opIt = ops.begin(); opIt != ops.end(); ++opIt) {
             if ((*opIt)->getType() == qc::Measure) {
-                if (!isLastOperationOnQubit(opIt)) {
-                    continue;
-                }
-
                 outputPermutationFromMeasurements = true;
                 auto op                           = dynamic_cast<NonUnitaryOperation*>(opIt->get());
                 assert(op->getTargets().size() == op->getClassics().size());
                 auto classicIt = op->getClassics().cbegin();
                 for (const auto& q: op->getTargets()) {
-                    auto qubitidx = q;
-                    auto bitidx   = *classicIt;
+                    const auto qubitidx = q;
+                    // only the first measurement of a qubit is used to determine the output permutation
+                    if (measuredQubits.count(qubitidx) != 0) {
+                        continue;
+                    }
+
+                    const auto bitidx = *classicIt;
                     if (outputPermutationFound) {
                         // output permutation was already set before -> permute existing values
-                        auto current = outputPermutation.at(qubitidx);
+                        const auto current = outputPermutation.at(qubitidx);
                         if (static_cast<std::size_t>(qubitidx) != bitidx && static_cast<std::size_t>(current) != bitidx) {
                             for (auto& p: outputPermutation) {
                                 if (static_cast<std::size_t>(p.second) == bitidx) {


### PR DESCRIPTION
The dynamic circuit transformation pass was not correctly handling `barrier` statements (leading to an endless loop).
Furthermore, the output permutation of a transformed circuit was messed up in some instances. This PR fixes both issues.