### PR TITLE
🚸 Check whether a logical qubit is contained in a circuit

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -264,17 +264,17 @@ namespace qc {
         [[nodiscard]] std::pair<std::string, dd::Qubit>   getQubitRegisterAndIndex(dd::Qubit physicalQubitIndex) const;
         [[nodiscard]] std::pair<std::string, std::size_t> getClassicalRegisterAndIndex(std::size_t classicalIndex) const;
 
-        [[nodiscard]] dd::Qubit                  getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
-        [[nodiscard]] std::size_t                getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
-        [[nodiscard]] bool                       isIdleQubit(dd::Qubit physicalQubit) const;
-        [[nodiscard]] bool                       isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const;
-        [[nodiscard]] bool                       physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const;
-        [[nodiscard]] bool                       logicalQubitIsAncillary(const dd::Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
-        void                                     setLogicalQubitAncillary(const dd::Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
-        [[nodiscard]] bool                       logicalQubitIsGarbage(const dd::Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
-        void                                     setLogicalQubitGarbage(dd::Qubit logicalQubitIndex);
-        [[nodiscard]] const std::vector<bool>&   getAncillary() const { return ancillary; }
-        [[nodiscard]] const std::vector<bool>&   getGarbage() const { return garbage; }
+        [[nodiscard]] dd::Qubit                getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
+        [[nodiscard]] std::size_t              getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
+        [[nodiscard]] bool                     isIdleQubit(dd::Qubit physicalQubit) const;
+        [[nodiscard]] bool                     isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const;
+        [[nodiscard]] bool                     physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const;
+        [[nodiscard]] bool                     logicalQubitIsAncillary(const dd::Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
+        void                                   setLogicalQubitAncillary(const dd::Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
+        [[nodiscard]] bool                     logicalQubitIsGarbage(const dd::Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
+        void                                   setLogicalQubitGarbage(dd::Qubit logicalQubitIndex);
+        [[nodiscard]] const std::vector<bool>& getAncillary() const { return ancillary; }
+        [[nodiscard]] const std::vector<bool>& getGarbage() const { return garbage; }
 
         /// checks whether the given logical qubit exists in the initial layout.
         /// \param logicalQubitIndex the logical qubit index to check

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -21,6 +21,7 @@
 #include <locale>
 #include <map>
 #include <memory>
+#include <optional>
 #include <random>
 #include <regex>
 #include <sstream>
@@ -263,17 +264,22 @@ namespace qc {
         [[nodiscard]] std::pair<std::string, dd::Qubit>   getQubitRegisterAndIndex(dd::Qubit physicalQubitIndex) const;
         [[nodiscard]] std::pair<std::string, std::size_t> getClassicalRegisterAndIndex(std::size_t classicalIndex) const;
 
-        [[nodiscard]] dd::Qubit                getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
-        [[nodiscard]] std::size_t              getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
-        [[nodiscard]] bool                     isIdleQubit(dd::Qubit physicalQubit) const;
-        [[nodiscard]] bool                     isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const;
-        [[nodiscard]] bool                     physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const;
-        [[nodiscard]] bool                     logicalQubitIsAncillary(dd::Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
-        void                                   setLogicalQubitAncillary(dd::Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
-        [[nodiscard]] bool                     logicalQubitIsGarbage(dd::Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
-        void                                   setLogicalQubitGarbage(dd::Qubit logicalQubitIndex);
-        [[nodiscard]] const std::vector<bool>& getAncillary() const { return ancillary; }
-        [[nodiscard]] const std::vector<bool>& getGarbage() const { return garbage; }
+        [[nodiscard]] dd::Qubit                  getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
+        [[nodiscard]] std::size_t                getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
+        [[nodiscard]] bool                       isIdleQubit(dd::Qubit physicalQubit) const;
+        [[nodiscard]] bool                       isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const;
+        [[nodiscard]] bool                       physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const;
+        [[nodiscard]] bool                       logicalQubitIsAncillary(const dd::Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
+        void                                     setLogicalQubitAncillary(const dd::Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
+        [[nodiscard]] bool                       logicalQubitIsGarbage(const dd::Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
+        void                                     setLogicalQubitGarbage(dd::Qubit logicalQubitIndex);
+        [[nodiscard]] const std::vector<bool>&   getAncillary() const { return ancillary; }
+        [[nodiscard]] const std::vector<bool>&   getGarbage() const { return garbage; }
+
+        /// checks whether the given logical qubit exists in the initial layout.
+        /// \param logicalQubitIndex the logical qubit index to check
+        /// \return whether the given logical qubit exists in the initial layout and to which physical qubit it is mapped
+        [[nodiscard]] std::pair<bool, std::optional<dd::Qubit>> containsLogicalQubit(dd::Qubit logicalQubitIndex) const;
 
         void i(dd::Qubit target) {
             checkQubitRange(target);

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -948,6 +948,19 @@ namespace qc {
         }
     }
 
+    [[nodiscard]] std::pair<bool, std::optional<dd::Qubit>> QuantumComputation::containsLogicalQubit(const dd::Qubit logicalQubitIndex) const {
+        if (const auto it = std::find_if(
+                    initialLayout.cbegin(),
+                    initialLayout.cend(),
+                    [&logicalQubitIndex](const auto& mapping) {
+                        return mapping.second == logicalQubitIndex;
+                    });
+            it != initialLayout.cend()) {
+            return {true, it->first};
+        }
+        return {false, {}};
+    }
+
     bool QuantumComputation::isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const {
         if (opIt == end)
             return true;

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1787,3 +1787,16 @@ TEST_F(QFRFunctionality, IndexOutOfRange) {
     EXPECT_THROW(qc.swap(0, 2, {dd::Control{1, dd::Control::Type::neg}}), QFRException);
     EXPECT_THROW(qc.reset({0, 1, 2}), QFRException);
 }
+
+TEST_F(QFRFunctionality, ContainsLogicalQubit) {
+    QuantumComputation qc(2);
+    const auto [contains0, index0] = qc.containsLogicalQubit(0);
+    EXPECT_TRUE(contains0);
+    EXPECT_EQ(*index0, 0);
+    const auto [contains1, index1] = qc.containsLogicalQubit(1);
+    EXPECT_TRUE(contains1);
+    EXPECT_EQ(*index1, 1);
+    const auto [contains2, index2] = qc.containsLogicalQubit(2);
+    EXPECT_FALSE(contains2);
+    EXPECT_FALSE(index2.has_value());
+}


### PR DESCRIPTION
This tiny PR adds a convenience function that allows to check whether a given logical qubit is present in the initial layout of a `QuantumComputation`.