### PR TITLE
🐛  Fix ancillary and garbage tracking when adding ancilla qubits

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -399,6 +399,10 @@ namespace qc {
         // index of logical qubit
         auto logical_qubit_index = static_cast<dd::Qubit>(nqubits + nancillae);
 
+        // resize ancillary and garbage tracking vectors
+        ancillary.resize(logical_qubit_index + 1U);
+        garbage.resize(logical_qubit_index + 1U);
+
         // increase ancillae count and mark as ancillary
         nancillae++;
         ancillary[logical_qubit_index] = true;

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1789,7 +1789,7 @@ TEST_F(QFRFunctionality, IndexOutOfRange) {
 }
 
 TEST_F(QFRFunctionality, ContainsLogicalQubit) {
-    QuantumComputation qc(2);
+    const QuantumComputation qc(2);
     const auto [contains0, index0] = qc.containsLogicalQubit(0);
     EXPECT_TRUE(contains0);
     EXPECT_EQ(*index0, 0);
@@ -1799,4 +1799,17 @@ TEST_F(QFRFunctionality, ContainsLogicalQubit) {
     const auto [contains2, index2] = qc.containsLogicalQubit(2);
     EXPECT_FALSE(contains2);
     EXPECT_FALSE(index2.has_value());
+}
+
+TEST_F(QFRFunctionality, AddAncillaryQubits) {
+    QuantumComputation qc(1);
+    qc.addAncillaryQubit(1, -1);
+    EXPECT_EQ(qc.getNqubits(), 2);
+    EXPECT_EQ(qc.getNancillae(), 1);
+    ASSERT_EQ(qc.ancillary.size(), 2U);
+    ASSERT_EQ(qc.garbage.size(), 2U);
+    EXPECT_FALSE(qc.ancillary[0]);
+    EXPECT_TRUE(qc.ancillary[1]);
+    EXPECT_FALSE(qc.garbage[0]);
+    EXPECT_TRUE(qc.garbage[1]);
 }


### PR DESCRIPTION
This PR fixes an issue that, when an ancilla qubit is added to a quantum computation, the `ancillary` and `garbage` vectors are not appropriately resized.
