### PR TITLE
🐛⚡ Enable `qiskit-terra>=0.22.0` compatibility

### DIFF
--- a/mqt/qfr/qiskit/QuantumCircuit.hpp
+++ b/mqt/qfr/qiskit/QuantumCircuit.hpp
@@ -367,7 +367,13 @@ namespace qc::qiskit {
             py::object Qubit = py::module::import("qiskit.circuit").attr("Qubit");
 
             // get layout
-            auto&& layout = circ.attr("_layout");
+            auto layout = circ.attr("_layout");
+
+            // qiskit-terra 0.22.0 changed the `_layout` attribute to a `TranspileLayout` dataclass object
+            // that contains the initial layout as a `Layout` object in the `initial_layout` attribute.
+            if (py::hasattr(layout, "initial_layout")) {
+                layout = layout.attr("initial_layout");
+            }
 
             // create map between registers used in the layout and logical qubit indices
             // NOTE: this only works correctly if the registers were originally declared in alphabetical order!


### PR DESCRIPTION
The latest `qiskit-terra` update (`0.22.0`) changed the way the initial layout information is stored in quantum circuits. 
Instead of a plain `Layout`, it now uses a `TranspileLayout` dataclass (see https://github.com/Qiskit/qiskit-terra/pull/8802)

This PR adapts the corresponding import function to react to this change and provide a working solution across qiskit-terra versions.
In addition, it fixes a few linter warnings in the corresponding function.