### PR TITLE
✨ Add Method for Determining Number of Single-Qubit Gates

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -259,6 +259,7 @@ namespace qc {
         std::vector<bool> garbage{};
 
         [[nodiscard]] std::size_t getNindividualOps() const;
+        [[nodiscard]] std::size_t getNsingleQubitOps() const;
 
         [[nodiscard]] std::string                         getQubitRegister(dd::Qubit physicalQubitIndex) const;
         [[nodiscard]] std::string                         getClassicalRegister(std::size_t classicalIndex) const;

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -32,9 +32,9 @@ namespace qc {
             }
 
             if (op->isCompoundOperation()) {
-                auto&& comp = dynamic_cast<CompoundOperation*>(op.get());
+                const auto* const comp = dynamic_cast<const CompoundOperation*>(op.get());
                 for (const auto& subop: *comp) {
-                    if (subop->getNcontrols() == 0U && subop->getNtargets() == 1U) {
+                    if (subop->isUnitary() && subop->getNcontrols() == 0U && subop->getNtargets() == 1U) {
                         ++nops;
                     }
                 }

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -24,6 +24,29 @@ namespace qc {
         return nops;
     }
 
+    std::size_t QuantumComputation::getNsingleQubitOps() const {
+        std::size_t nops = 0;
+        for (const auto& op: ops) {
+            if (!op->isUnitary()) {
+                continue;
+            }
+
+            if (op->isCompoundOperation()) {
+                auto&& comp = dynamic_cast<CompoundOperation*>(op.get());
+                for (const auto& subop: *comp) {
+                    if (subop->getNcontrols() == 0U && subop->getNtargets() == 1U) {
+                        ++nops;
+                    }
+                }
+            } else {
+                if (op->getNcontrols() == 0U && op->getNtargets() == 1U) {
+                    ++nops;
+                }
+            }
+        }
+        return nops;
+    }
+
     void QuantumComputation::import(const std::string& filename) {
         size_t      dot       = filename.find_last_of('.');
         std::string extension = filename.substr(dot + 1);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1813,3 +1813,22 @@ TEST_F(QFRFunctionality, AddAncillaryQubits) {
     EXPECT_FALSE(qc.garbage[0]);
     EXPECT_TRUE(qc.garbage[1]);
 }
+
+TEST_F(QFRFunctionality, SingleQubitGateCount) {
+    QuantumComputation qc(2);
+    qc.x(0);
+    qc.h(0);
+    qc.x(0, 1_pc);
+    qc.z(0);
+    qc.measure(0, 0);
+
+    EXPECT_EQ(qc.getNops(), 5U);
+    EXPECT_EQ(qc.getNindividualOps(), 5U);
+    EXPECT_EQ(qc.getNsingleQubitOps(), 3U);
+
+    CircuitOptimizer::singleQubitGateFusion(qc);
+
+    EXPECT_EQ(qc.getNops(), 4U);
+    EXPECT_EQ(qc.getNindividualOps(), 5U);
+    EXPECT_EQ(qc.getNsingleQubitOps(), 3U);
+}


### PR DESCRIPTION
This PR adds a method for quickly determining the number of single-qubit gates in a circuit. 
Such a function turns out to be useful in upstream projects such as QMAP.