### PR TITLE
♻️ DD-independent QFR-Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         name: Coverage
         run: |
           cmake -S . -B buildCov -DCMAKE_BUILD_TYPE=Debug -DBUILD_QFR_TESTS=ON -DCOVERAGE=ON
-          cmake --build buildCov --config Debug --target qfr_test
+          cmake --build buildCov --config Debug
           cd buildCov/test
           ctest -C Debug --output-on-failure
       - if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ It acts as an intermediate representation and provides the facilitites to
 ### System Requirements
 
 Building (and running) is continuously tested under Linux, MacOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments). However, the implementation should be compatible
-with any current C++ compiler supporting C++17 and a minimum CMake version of 3.14.
+with any current C++ compiler supporting C++17 and a minimum CMake version of 3.19.
 
 _Disclaimer_: We noticed some issues when compiling with Microsoft's `MSVC` compiler toolchain. If you are developing under Windows, consider using the `clang` compiler toolchain. A detailed description of how to set this up can be
 found [here](https://docs.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-160).
@@ -197,11 +197,12 @@ Some operating systems and developer environments explicitly require a configura
 
 Building the project this way generates
 
-- the library `libqfr.a` (Unix) / `qfr.lib` (Windows) in the `build/src` folder
-- a test executable `qfr_test` containing a small set of unit tests in the `build/test` folder
+- the core library `libqfr.a` (Unix) / `qfr.lib` (Windows) in the `build/src` folder
+- the DD and ZX libraries `libqfr_dd.a` (Unix) / `qfr_dd.lib` (Windows) and `libqfr_zx.a` (Unix) / `qfr_zx.lib` (Windows) in the `build/src/` folder
+- test executables `qfr_test`, `qfr_test_dd`, and `qfr_test_zx` containing a small set of unit tests in the `build/test` folder
 - a small demo example executable `qfr_example` in the `build/test` directory.
 
-You can link against the library built by this project in other CMake project using the `MQT::qfr` target.
+You can link against the library built by this project in other CMake project using the `MQT::qfr` target (or any of the other targets `MQT::qfr_dd` and `MQT::qfr_zx`).
 
 ### Extending the Python Package
 

--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -7,14 +7,13 @@
 
 #include "Definitions.hpp"
 #include "QuantumComputation.hpp"
-#include "dd/Package.hpp"
 #include "operations/Operation.hpp"
 
 #include <array>
 #include <memory>
 
 namespace qc {
-    static constexpr std::array<qc::OpType, 8> diagonalGates = {qc::I, qc::Z, qc::S, qc::Sdag, qc::T, qc::Tdag, qc::Phase, qc::RZ};
+    static constexpr std::array<qc::OpType, 8> DIAGONAL_GATES = {qc::I, qc::Z, qc::S, qc::Sdag, qc::T, qc::Tdag, qc::Phase, qc::RZ};
 
     class CircuitOptimizer {
     protected:
@@ -55,14 +54,14 @@ namespace qc {
         static void cancelCNOTs(QuantumComputation& qc);
 
     protected:
-        static void removeDiagonalGatesBeforeMeasureRecursive(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, const DAGReverseIterator& until);
-        static bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, DAGReverseIterator& it, qc::Operation* op);
+        static void removeDiagonalGatesBeforeMeasureRecursive(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx, const DAGReverseIterator& until);
+        static bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx, DAGReverseIterator& it, qc::Operation* op);
 
-        static void removeFinalMeasurementsRecursive(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, const DAGReverseIterator& until);
-        static bool removeFinalMeasurement(DAG& dag, DAGReverseIterators& dagIterators, dd::Qubit idx, DAGReverseIterator& it, qc::Operation* op);
+        static void removeFinalMeasurementsRecursive(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx, const DAGReverseIterator& until);
+        static bool removeFinalMeasurement(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx, DAGReverseIterator& it, qc::Operation* op);
 
-        static void changeTargets(Targets& targets, const std::map<dd::Qubit, dd::Qubit>& replacementMap);
-        static void changeControls(dd::Controls& controls, const std::map<dd::Qubit, dd::Qubit>& replacementMap);
+        static void changeTargets(Targets& targets, const std::map<Qubit, Qubit>& replacementMap);
+        static void changeControls(Controls& controls, const std::map<Qubit, Qubit>& replacementMap);
 
         using Iterator = decltype(qc::QuantumComputation::ops.begin());
         static Iterator flattenCompoundOperation(std::vector<std::unique_ptr<Operation>>& ops, Iterator it);

--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -6,8 +6,6 @@
 #pragma once
 
 #include "Expression.hpp"
-#include "dd/Control.hpp"
-#include "dd/Definitions.hpp"
 
 #include <bitset>
 #include <deque>
@@ -30,44 +28,37 @@ namespace qc {
         }
     };
 
+    using Qubit = std::uint32_t;
+    using Bit   = std::uint64_t;
+
     template<class IdxType, class SizeType>
     using Register          = std::pair<IdxType, SizeType>;
-    using QuantumRegister   = Register<dd::Qubit, dd::QubitCount>;
-    using ClassicalRegister = Register<std::size_t, std::size_t>;
+    using QuantumRegister   = Register<Qubit, std::size_t>;
+    using ClassicalRegister = Register<Bit, std::size_t>;
     template<class RegisterType>
     using RegisterMap          = std::map<std::string, RegisterType, std::greater<>>;
     using QuantumRegisterMap   = RegisterMap<QuantumRegister>;
     using ClassicalRegisterMap = RegisterMap<ClassicalRegister>;
     using RegisterNames        = std::vector<std::pair<std::string, std::string>>;
 
-    using Targets = std::vector<dd::Qubit>;
+    using Targets = std::vector<Qubit>;
 
-    using BitString = std::bitset<std::numeric_limits<dd::Qubit>::max() + 1>;
+    using BitString = std::bitset<128>;
 
-    struct Permutation: public std::map<dd::Qubit, dd::Qubit> {
-        [[nodiscard]] inline dd::Controls apply(const dd::Controls& controls) const {
-            dd::Controls c{};
-            for (const auto& control: controls) {
-                c.emplace(dd::Control{at(control.qubit), control.type});
-            }
-            return c;
-        }
-        [[nodiscard]] inline Targets apply(const Targets& targets) const {
-            Targets t{};
-            for (const auto& target: targets) {
-                t.emplace_back(at(target));
-            }
-            return t;
-        }
-    };
+    // floating-point type used throughout the library
+    using fp = double;
 
-    constexpr dd::fp PARAMETER_TOLERANCE = 1e-13;
+    constexpr fp PARAMETER_TOLERANCE = 1e-13;
+
+    static constexpr fp PI   = static_cast<fp>(3.141592653589793238462643383279502884197169399375105820974L);
+    static constexpr fp PI_2 = static_cast<fp>(1.570796326794896619231321691639751442098584699687552910487L);
+    static constexpr fp PI_4 = static_cast<fp>(0.785398163397448309615660845819875721049292349843776455243L);
 
     // forward declaration
     class Operation;
 
     // supported file formats
-    enum Format {
+    enum class Format {
         Real,
         OpenQASM,
         GRCS,
@@ -82,7 +73,7 @@ namespace qc {
     using DAGIterators        = std::vector<DAGIterator>;
     using DAGReverseIterators = std::vector<DAGReverseIterator>;
 
-    using Symbolic           = sym::Expression<double, double>;
-    using VariableAssignment = std::unordered_map<sym::Variable, dd::fp>;
-    using SymbolOrNumber     = std::variant<Symbolic, dd::fp>;
+    using Symbolic           = sym::Expression<fp, fp>;
+    using VariableAssignment = std::unordered_map<sym::Variable, fp>;
+    using SymbolOrNumber     = std::variant<Symbolic, fp>;
 } // namespace qc

--- a/include/Permutation.hpp
+++ b/include/Permutation.hpp
@@ -1,0 +1,31 @@
+/*
+* This file is part of MQT QFR library which is released under the MIT license.
+* See file README.md or go to https://www.cda.cit.tum.de/research/quantum/ for more information.
+*/
+
+#pragma once
+
+#include "Definitions.hpp"
+#include "operations/Control.hpp"
+
+#include <map>
+
+namespace qc {
+    class Permutation: public std::map<Qubit, Qubit> {
+    public:
+        [[nodiscard]] inline Controls apply(const Controls& controls) const {
+            Controls c{};
+            for (const auto& control: controls) {
+                c.emplace(Control{at(control.qubit), control.type});
+            }
+            return c;
+        }
+        [[nodiscard]] inline Targets apply(const Targets& targets) const {
+            Targets t{};
+            for (const auto& target: targets) {
+                t.emplace_back(at(target));
+            }
+            return t;
+        }
+    };
+} // namespace qc

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -6,8 +6,6 @@
 #pragma once
 
 #include "Definitions.hpp"
-#include "dd/Definitions.hpp"
-#include "dd/Operations.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/NonUnitaryOperation.hpp"
 #include "operations/StandardOperation.hpp"
@@ -32,7 +30,6 @@ namespace qc {
     static constexpr char DEFAULT_QREG[2]{"q"};
     static constexpr char DEFAULT_CREG[2]{"c"};
     static constexpr char DEFAULT_ANCREG[4]{"anc"};
-    static constexpr char DEFAULT_MCTREG[4]{"mct"};
 
     class CircuitOptimizer;
 
@@ -45,13 +42,13 @@ namespace qc {
 
     protected:
         std::vector<std::unique_ptr<Operation>> ops{};
-        dd::QubitCount                          nqubits      = 0;
+        std::size_t                             nqubits      = 0;
         std::size_t                             nclassics    = 0;
-        dd::QubitCount                          nancillae    = 0;
-        dd::QubitCount                          max_controls = 0;
+        std::size_t                             nancillae    = 0;
+        std::size_t                             max_controls = 0;
         std::string                             name;
 
-        // reg[reg_name] = {start_index, length}
+        // register names are used as keys, while the values are `{startIndex, length}` pairs
         QuantumRegisterMap   qregs{};
         ClassicalRegisterMap cregs{};
         QuantumRegisterMap   ancregs{};
@@ -66,11 +63,11 @@ namespace qc {
         int  readRealHeader(std::istream& is);
         void readRealGateDescriptions(std::istream& is, int line);
         void importTFC(std::istream& is);
-        int  readTFCHeader(std::istream& is, std::map<std::string, dd::Qubit>& varMap);
-        void readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, dd::Qubit>& varMap);
+        int  readTFCHeader(std::istream& is, std::map<std::string, Qubit>& varMap);
+        void readTFCGateDescriptions(std::istream& is, int line, std::map<std::string, Qubit>& varMap);
         void importQC(std::istream& is);
-        int  readQCHeader(std::istream& is, std::map<std::string, dd::Qubit>& varMap);
-        void readQCGateDescriptions(std::istream& is, int line, std::map<std::string, dd::Qubit>& varMap);
+        int  readQCHeader(std::istream& is, std::map<std::string, Qubit>& varMap);
+        void readQCGateDescriptions(std::istream& is, int line, std::map<std::string, Qubit>& varMap);
         void importGRCS(std::istream& is);
 
         template<class RegisterType>
@@ -82,7 +79,7 @@ namespace qc {
             }
 
             for (const auto& reg: sortedRegs) {
-                of << identifier << " " << reg.second.first << "[" << static_cast<std::size_t>(reg.second.second.second) << "];" << std::endl;
+                of << identifier << " " << reg.second.first << "[" << reg.second.second.second << "];" << std::endl;
             }
         }
         template<class RegisterType>
@@ -133,14 +130,14 @@ namespace qc {
 
                 for (const auto& reg: sortedRegs) {
                     for (decltype(RegisterType::second) i = 0; i < reg.second.second.second; i++) {
-                        ss << reg.second.first << "[" << static_cast<std::size_t>(i) << "]";
+                        ss << reg.second.first << "[" << i << "]";
                         regnames.push_back(std::make_pair(reg.second.first, ss.str()));
                         ss.str(std::string());
                     }
                 }
             } else {
                 for (decltype(RegisterType::second) i = 0; i < defaultnumber; i++) {
-                    ss << defaultname << "[" << static_cast<std::size_t>(i) << "]";
+                    ss << defaultname << "[" << i << "]";
                     regnames.push_back(std::make_pair(defaultname, ss.str()));
                     ss.str(std::string());
                 }
@@ -149,16 +146,18 @@ namespace qc {
 
         [[nodiscard]] std::size_t getSmallestAncillary() const {
             for (std::size_t i = 0; i < ancillary.size(); ++i) {
-                if (ancillary[i])
+                if (ancillary[i]) {
                     return i;
+                }
             }
             return ancillary.size();
         }
 
         [[nodiscard]] std::size_t getSmallestGarbage() const {
             for (std::size_t i = 0; i < garbage.size(); ++i) {
-                if (garbage[i])
+                if (garbage[i]) {
                     return i;
+                }
             }
             return garbage.size();
         }
@@ -166,17 +165,17 @@ namespace qc {
             const auto end = ops.cend();
             return isLastOperationOnQubit(opIt, end);
         }
-        void checkQubitRange(dd::Qubit qubit) const;
-        void checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1) const;
-        void checkQubitRange(dd::Qubit qubit, const dd::Control& control) const;
-        void checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1, const dd::Control& control) const;
-        void checkQubitRange(dd::Qubit qubit, const dd::Controls& controls) const;
-        void checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1, const dd::Controls& controls) const;
-        void checkQubitRange(const std::vector<dd::Qubit>& qubits) const;
+        void checkQubitRange(Qubit qubit) const;
+        void checkQubitRange(Qubit qubit0, Qubit qubit1) const;
+        void checkQubitRange(Qubit qubit, const Control& control) const;
+        void checkQubitRange(Qubit qubit0, Qubit qubit1, const Control& control) const;
+        void checkQubitRange(Qubit qubit, const Controls& controls) const;
+        void checkQubitRange(Qubit qubit0, Qubit qubit1, const Controls& controls) const;
+        void checkQubitRange(const std::vector<Qubit>& qubits) const;
 
     public:
         QuantumComputation() = default;
-        explicit QuantumComputation(std::size_t nqubits, std::size_t seed = 0):
+        explicit QuantumComputation(const std::size_t nqubits, const std::size_t seed = 0):
             seed(seed) {
             addQubitRegister(nqubits);
             addClassicalRegister(nqubits);
@@ -184,24 +183,24 @@ namespace qc {
                 mt.seed(seed);
             } else {
                 // create and properly seed rng
-                std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> random_data{};
+                std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> randomData{};
                 std::random_device                                                    rd;
-                std::generate(std::begin(random_data), std::end(random_data), [&rd]() { return rd(); });
-                std::seed_seq seeds(std::begin(random_data), std::end(random_data));
+                std::generate(std::begin(randomData), std::end(randomData), [&rd]() { return rd(); });
+                std::seed_seq seeds(std::begin(randomData), std::end(randomData));
                 mt.seed(seeds);
             }
         }
-        explicit QuantumComputation(const std::string& filename, std::size_t seed = 0U):
+        explicit QuantumComputation(const std::string& filename, const std::size_t seed = 0U):
             seed(seed) {
             import(filename);
             if (seed != 0U) {
                 mt.seed(seed);
             } else {
                 // create and properly seed rng
-                std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> random_data{};
+                std::array<std::mt19937_64::result_type, std::mt19937_64::state_size> randomData{};
                 std::random_device                                                    rd;
-                std::generate(std::begin(random_data), std::end(random_data), [&rd]() { return rd(); });
-                std::seed_seq seeds(std::begin(random_data), std::end(random_data));
+                std::generate(std::begin(randomData), std::end(randomData), [&rd]() { return rd(); });
+                std::seed_seq seeds(std::begin(randomData), std::end(randomData));
                 mt.seed(seeds);
             }
         }
@@ -239,9 +238,9 @@ namespace qc {
         }
 
         [[nodiscard]] virtual std::size_t         getNops() const { return ops.size(); }
-        [[nodiscard]] dd::QubitCount              getNqubits() const { return nqubits + nancillae; }
-        [[nodiscard]] dd::QubitCount              getNancillae() const { return nancillae; }
-        [[nodiscard]] dd::QubitCount              getNqubitsWithoutAncillae() const { return nqubits; }
+        [[nodiscard]] std::size_t                 getNqubits() const { return nqubits + nancillae; }
+        [[nodiscard]] std::size_t                 getNancillae() const { return nancillae; }
+        [[nodiscard]] std::size_t                 getNqubitsWithoutAncillae() const { return nqubits; }
         [[nodiscard]] std::size_t                 getNcbits() const { return nclassics; }
         [[nodiscard]] std::string                 getName() const { return name; }
         [[nodiscard]] const QuantumRegisterMap&   getQregs() const { return qregs; }
@@ -251,7 +250,7 @@ namespace qc {
 
         void setName(const std::string& n) { name = n; }
 
-        // initialLayout[physical_qubit] = logical_qubit
+        // physical qubits are used as keys, logical qubits as values
         Permutation initialLayout{};
         Permutation outputPermutation{};
 
@@ -262,385 +261,385 @@ namespace qc {
         [[nodiscard]] std::size_t getNsingleQubitOps() const;
         [[nodiscard]] std::size_t getDepth() const;
 
-        [[nodiscard]] std::string                         getQubitRegister(dd::Qubit physicalQubitIndex) const;
-        [[nodiscard]] std::string                         getClassicalRegister(std::size_t classicalIndex) const;
-        static dd::Qubit                                  getHighestLogicalQubitIndex(const Permutation& map);
-        [[nodiscard]] dd::Qubit                           getHighestLogicalQubitIndex() const { return getHighestLogicalQubitIndex(initialLayout); };
-        [[nodiscard]] std::pair<std::string, dd::Qubit>   getQubitRegisterAndIndex(dd::Qubit physicalQubitIndex) const;
-        [[nodiscard]] std::pair<std::string, std::size_t> getClassicalRegisterAndIndex(std::size_t classicalIndex) const;
+        [[nodiscard]] std::string                   getQubitRegister(Qubit physicalQubitIndex) const;
+        [[nodiscard]] std::string                   getClassicalRegister(Bit classicalIndex) const;
+        static Qubit                                getHighestLogicalQubitIndex(const Permutation& map);
+        [[nodiscard]] Qubit                         getHighestLogicalQubitIndex() const { return getHighestLogicalQubitIndex(initialLayout); };
+        [[nodiscard]] std::pair<std::string, Qubit> getQubitRegisterAndIndex(Qubit physicalQubitIndex) const;
+        [[nodiscard]] std::pair<std::string, Bit>   getClassicalRegisterAndIndex(Bit classicalIndex) const;
 
-        [[nodiscard]] dd::Qubit                getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const;
-        [[nodiscard]] std::size_t              getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
-        [[nodiscard]] bool                     isIdleQubit(dd::Qubit physicalQubit) const;
+        [[nodiscard]] Qubit                    getIndexFromQubitRegister(const std::pair<std::string, Qubit>& qubit) const;
+        [[nodiscard]] Bit                      getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const;
+        [[nodiscard]] bool                     isIdleQubit(Qubit physicalQubit) const;
         [[nodiscard]] bool                     isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const;
-        [[nodiscard]] bool                     physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const;
-        [[nodiscard]] bool                     logicalQubitIsAncillary(const dd::Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
-        void                                   setLogicalQubitAncillary(const dd::Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
-        [[nodiscard]] bool                     logicalQubitIsGarbage(const dd::Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
-        void                                   setLogicalQubitGarbage(dd::Qubit logicalQubitIndex);
+        [[nodiscard]] bool                     physicalQubitIsAncillary(Qubit physicalQubitIndex) const;
+        [[nodiscard]] bool                     logicalQubitIsAncillary(const Qubit logicalQubitIndex) const { return ancillary[logicalQubitIndex]; }
+        void                                   setLogicalQubitAncillary(const Qubit logicalQubitIndex) { ancillary[logicalQubitIndex] = true; }
+        [[nodiscard]] bool                     logicalQubitIsGarbage(const Qubit logicalQubitIndex) const { return garbage[logicalQubitIndex]; }
+        void                                   setLogicalQubitGarbage(Qubit logicalQubitIndex);
         [[nodiscard]] const std::vector<bool>& getAncillary() const { return ancillary; }
         [[nodiscard]] const std::vector<bool>& getGarbage() const { return garbage; }
 
         /// checks whether the given logical qubit exists in the initial layout.
         /// \param logicalQubitIndex the logical qubit index to check
         /// \return whether the given logical qubit exists in the initial layout and to which physical qubit it is mapped
-        [[nodiscard]] std::pair<bool, std::optional<dd::Qubit>> containsLogicalQubit(dd::Qubit logicalQubitIndex) const;
+        [[nodiscard]] std::pair<bool, std::optional<Qubit>> containsLogicalQubit(Qubit logicalQubitIndex) const;
 
-        void i(dd::Qubit target) {
+        void i(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::I);
         }
-        void i(dd::Qubit target, const dd::Control& control) {
+        void i(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::I);
         }
-        void i(dd::Qubit target, const dd::Controls& controls) {
+        void i(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::I);
         }
 
-        void h(dd::Qubit target) {
+        void h(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::H);
         }
-        void h(dd::Qubit target, const dd::Control& control) {
+        void h(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::H);
         }
-        void h(dd::Qubit target, const dd::Controls& controls) {
+        void h(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::H);
         }
 
-        void x(dd::Qubit target) {
+        void x(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::X);
         }
-        void x(dd::Qubit target, const dd::Control& control) {
+        void x(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::X);
         }
-        void x(dd::Qubit target, const dd::Controls& controls) {
+        void x(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::X);
         }
 
-        void y(dd::Qubit target) {
+        void y(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Y);
         }
-        void y(dd::Qubit target, const dd::Control& control) {
+        void y(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Y);
         }
-        void y(dd::Qubit target, const dd::Controls& controls) {
+        void y(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Y);
         }
 
-        void z(dd::Qubit target) {
+        void z(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Z);
         }
-        void z(dd::Qubit target, const dd::Control& control) {
+        void z(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Z);
         }
-        void z(dd::Qubit target, const dd::Controls& controls) {
+        void z(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Z);
         }
 
-        void s(dd::Qubit target) {
+        void s(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::S);
         }
-        void s(dd::Qubit target, const dd::Control& control) {
+        void s(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::S);
         }
-        void s(dd::Qubit target, const dd::Controls& controls) {
+        void s(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::S);
         }
 
-        void sdag(dd::Qubit target) {
+        void sdag(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Sdag);
         }
-        void sdag(dd::Qubit target, const dd::Control& control) {
+        void sdag(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Sdag);
         }
-        void sdag(dd::Qubit target, const dd::Controls& controls) {
+        void sdag(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Sdag);
         }
 
-        void t(dd::Qubit target) {
+        void t(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::T);
         }
-        void t(dd::Qubit target, const dd::Control& control) {
+        void t(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::T);
         }
-        void t(dd::Qubit target, const dd::Controls& controls) {
+        void t(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::T);
         }
 
-        void tdag(dd::Qubit target) {
+        void tdag(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Tdag);
         }
-        void tdag(dd::Qubit target, const dd::Control& control) {
+        void tdag(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Tdag);
         }
-        void tdag(dd::Qubit target, const dd::Controls& controls) {
+        void tdag(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Tdag);
         }
 
-        void v(dd::Qubit target) {
+        void v(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::V);
         }
-        void v(dd::Qubit target, const dd::Control& control) {
+        void v(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::V);
         }
-        void v(dd::Qubit target, const dd::Controls& controls) {
+        void v(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::V);
         }
 
-        void vdag(dd::Qubit target) {
+        void vdag(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Vdag);
         }
-        void vdag(dd::Qubit target, const dd::Control& control) {
+        void vdag(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Vdag);
         }
-        void vdag(dd::Qubit target, const dd::Controls& controls) {
+        void vdag(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Vdag);
         }
 
-        void u3(dd::Qubit target, dd::fp lambda, dd::fp phi, dd::fp theta) {
+        void u3(Qubit target, fp lambda, fp phi, fp theta) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::U3, lambda, phi, theta);
         }
-        void u3(dd::Qubit target, const dd::Control& control, dd::fp lambda, dd::fp phi, dd::fp theta) {
+        void u3(Qubit target, const Control& control, fp lambda, fp phi, fp theta) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::U3, lambda, phi, theta);
         }
-        void u3(dd::Qubit target, const dd::Controls& controls, dd::fp lambda, dd::fp phi, dd::fp theta) {
+        void u3(Qubit target, const Controls& controls, fp lambda, fp phi, fp theta) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::U3, lambda, phi, theta);
         }
-        void u3(dd::Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
-        void u3(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
-        void u3(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
+        void u3(Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
+        void u3(Qubit target, const Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
+        void u3(Qubit target, const Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta);
 
-        void u2(dd::Qubit target, dd::fp lambda, dd::fp phi) {
+        void u2(Qubit target, fp lambda, fp phi) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::U2, lambda, phi);
         }
-        void u2(dd::Qubit target, const dd::Control& control, dd::fp lambda, dd::fp phi) {
+        void u2(Qubit target, const Control& control, fp lambda, fp phi) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::U2, lambda, phi);
         }
-        void u2(dd::Qubit target, const dd::Controls& controls, dd::fp lambda, dd::fp phi) {
+        void u2(Qubit target, const Controls& controls, fp lambda, fp phi) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::U2, lambda, phi);
         }
-        void u2(dd::Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
-        void u2(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
-        void u2(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
+        void u2(Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
+        void u2(Qubit target, const Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
+        void u2(Qubit target, const Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi);
 
-        void phase(dd::Qubit target, dd::fp lambda) {
+        void phase(Qubit target, fp lambda) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::Phase, lambda);
         }
-        void phase(dd::Qubit target, const dd::Control& control, dd::fp lambda) {
+        void phase(Qubit target, const Control& control, fp lambda) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::Phase, lambda);
         }
-        void phase(dd::Qubit target, const dd::Controls& controls, dd::fp lambda) {
+        void phase(Qubit target, const Controls& controls, fp lambda) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::Phase, lambda);
         }
-        void phase(dd::Qubit target, const SymbolOrNumber& lambda);
-        void phase(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda);
-        void phase(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda);
+        void phase(Qubit target, const SymbolOrNumber& lambda);
+        void phase(Qubit target, const Control& control, const SymbolOrNumber& lambda);
+        void phase(Qubit target, const Controls& controls, const SymbolOrNumber& lambda);
 
-        void sx(dd::Qubit target) {
+        void sx(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::SX);
         }
-        void sx(dd::Qubit target, const dd::Control& control) {
+        void sx(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::SX);
         }
-        void sx(dd::Qubit target, const dd::Controls& controls) {
+        void sx(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::SX);
         }
 
-        void sxdag(dd::Qubit target) {
+        void sxdag(Qubit target) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::SXdag);
         }
-        void sxdag(dd::Qubit target, const dd::Control& control) {
+        void sxdag(Qubit target, const Control& control) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::SXdag);
         }
-        void sxdag(dd::Qubit target, const dd::Controls& controls) {
+        void sxdag(Qubit target, const Controls& controls) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::SXdag);
         }
 
-        void rx(dd::Qubit target, dd::fp lambda) {
+        void rx(Qubit target, fp lambda) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::RX, lambda);
         }
-        void rx(dd::Qubit target, const dd::Control& control, dd::fp lambda) {
+        void rx(Qubit target, const Control& control, fp lambda) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::RX, lambda);
         }
-        void rx(dd::Qubit target, const dd::Controls& controls, dd::fp lambda) {
+        void rx(Qubit target, const Controls& controls, fp lambda) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::RX, lambda);
         }
-        void rx(dd::Qubit target, const SymbolOrNumber& lambda);
-        void rx(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda);
-        void rx(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda);
+        void rx(Qubit target, const SymbolOrNumber& lambda);
+        void rx(Qubit target, const Control& control, const SymbolOrNumber& lambda);
+        void rx(Qubit target, const Controls& controls, const SymbolOrNumber& lambda);
 
-        void ry(dd::Qubit target, dd::fp lambda) {
+        void ry(Qubit target, fp lambda) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::RY, lambda);
         }
-        void ry(dd::Qubit target, const dd::Control& control, dd::fp lambda) {
+        void ry(Qubit target, const Control& control, fp lambda) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::RY, lambda);
         }
-        void ry(dd::Qubit target, const dd::Controls& controls, dd::fp lambda) {
+        void ry(Qubit target, const Controls& controls, fp lambda) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::RY, lambda);
         }
 
-        void ry(dd::Qubit target, const SymbolOrNumber& lambda);
-        void ry(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda);
-        void ry(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda);
+        void ry(Qubit target, const SymbolOrNumber& lambda);
+        void ry(Qubit target, const Control& control, const SymbolOrNumber& lambda);
+        void ry(Qubit target, const Controls& controls, const SymbolOrNumber& lambda);
 
-        void rz(dd::Qubit target, dd::fp lambda) {
+        void rz(Qubit target, fp lambda) {
             checkQubitRange(target);
             emplace_back<StandardOperation>(getNqubits(), target, qc::RZ, lambda);
         }
-        void rz(dd::Qubit target, const dd::Control& control, dd::fp lambda) {
+        void rz(Qubit target, const Control& control, fp lambda) {
             checkQubitRange(target, control);
             emplace_back<StandardOperation>(getNqubits(), control, target, qc::RZ, lambda);
         }
-        void rz(dd::Qubit target, const dd::Controls& controls, dd::fp lambda) {
+        void rz(Qubit target, const Controls& controls, fp lambda) {
             checkQubitRange(target, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target, qc::RZ, lambda);
         }
 
-        void rz(dd::Qubit target, const SymbolOrNumber& lambda);
-        void rz(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda);
-        void rz(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda);
+        void rz(Qubit target, const SymbolOrNumber& lambda);
+        void rz(Qubit target, const Control& control, const SymbolOrNumber& lambda);
+        void rz(Qubit target, const Controls& controls, const SymbolOrNumber& lambda);
 
-        void swap(dd::Qubit target0, dd::Qubit target1) {
+        void swap(Qubit target0, Qubit target1) {
             checkQubitRange(target0, target1);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{}, target0, target1, qc::SWAP);
+            emplace_back<StandardOperation>(getNqubits(), Controls{}, target0, target1, qc::SWAP);
         }
-        void swap(dd::Qubit target0, dd::Qubit target1, const dd::Control& control) {
+        void swap(Qubit target0, Qubit target1, const Control& control) {
             checkQubitRange(target0, target1, control);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{control}, target0, target1, qc::SWAP);
+            emplace_back<StandardOperation>(getNqubits(), Controls{control}, target0, target1, qc::SWAP);
         }
-        void swap(dd::Qubit target0, dd::Qubit target1, const dd::Controls& controls) {
+        void swap(Qubit target0, Qubit target1, const Controls& controls) {
             checkQubitRange(target0, target1, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target0, target1, qc::SWAP);
         }
 
-        void iswap(dd::Qubit target0, dd::Qubit target1) {
+        void iswap(Qubit target0, Qubit target1) {
             checkQubitRange(target0, target1);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{}, target0, target1, qc::iSWAP);
+            emplace_back<StandardOperation>(getNqubits(), Controls{}, target0, target1, qc::iSWAP);
         }
-        void iswap(dd::Qubit target0, dd::Qubit target1, const dd::Control& control) {
+        void iswap(Qubit target0, Qubit target1, const Control& control) {
             checkQubitRange(target0, target1, control);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{control}, target0, target1, qc::iSWAP);
+            emplace_back<StandardOperation>(getNqubits(), Controls{control}, target0, target1, qc::iSWAP);
         }
-        void iswap(dd::Qubit target0, dd::Qubit target1, const dd::Controls& controls) {
+        void iswap(Qubit target0, Qubit target1, const Controls& controls) {
             checkQubitRange(target0, target1, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target0, target1, qc::iSWAP);
         }
 
-        void peres(dd::Qubit target0, dd::Qubit target1) {
+        void peres(Qubit target0, Qubit target1) {
             checkQubitRange(target0, target1);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{}, target0, target1, qc::Peres);
+            emplace_back<StandardOperation>(getNqubits(), Controls{}, target0, target1, qc::Peres);
         }
-        void peres(dd::Qubit target0, dd::Qubit target1, const dd::Control& control) {
+        void peres(Qubit target0, Qubit target1, const Control& control) {
             checkQubitRange(target0, target1, control);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{control}, target0, target1, qc::Peres);
+            emplace_back<StandardOperation>(getNqubits(), Controls{control}, target0, target1, qc::Peres);
         }
-        void peres(dd::Qubit target0, dd::Qubit target1, const dd::Controls& controls) {
+        void peres(Qubit target0, Qubit target1, const Controls& controls) {
             checkQubitRange(target0, target1, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target0, target1, qc::Peres);
         }
 
-        void peresdag(dd::Qubit target0, dd::Qubit target1) {
+        void peresdag(Qubit target0, Qubit target1) {
             checkQubitRange(target0, target1);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{}, target0, target1, qc::Peresdag);
+            emplace_back<StandardOperation>(getNqubits(), Controls{}, target0, target1, qc::Peresdag);
         }
-        void peresdag(dd::Qubit target0, dd::Qubit target1, const dd::Control& control) {
+        void peresdag(Qubit target0, Qubit target1, const Control& control) {
             checkQubitRange(target0, target1, control);
-            emplace_back<StandardOperation>(getNqubits(), dd::Controls{control}, target0, target1, qc::Peresdag);
+            emplace_back<StandardOperation>(getNqubits(), Controls{control}, target0, target1, qc::Peresdag);
         }
-        void peresdag(dd::Qubit target0, dd::Qubit target1, const dd::Controls& controls) {
+        void peresdag(Qubit target0, Qubit target1, const Controls& controls) {
             checkQubitRange(target0, target1, controls);
             emplace_back<StandardOperation>(getNqubits(), controls, target0, target1, qc::Peresdag);
         }
 
-        void measure(dd::Qubit qubit, std::size_t clbit) {
+        void measure(Qubit qubit, std::size_t clbit) {
             checkQubitRange(qubit);
             emplace_back<NonUnitaryOperation>(getNqubits(), qubit, clbit);
         }
-        void measure(const std::vector<dd::Qubit>&   qubitRegister,
-                     const std::vector<std::size_t>& classicalRegister) {
+        void measure(const std::vector<Qubit>& qubitRegister,
+                     const std::vector<Bit>&   classicalRegister) {
             checkQubitRange(qubitRegister);
             emplace_back<NonUnitaryOperation>(getNqubits(), qubitRegister,
                                               classicalRegister);
         }
 
-        void reset(dd::Qubit target) {
+        void reset(Qubit target) {
             checkQubitRange(target);
-            emplace_back<NonUnitaryOperation>(getNqubits(), std::vector<dd::Qubit>{target}, qc::Reset);
+            emplace_back<NonUnitaryOperation>(getNqubits(), std::vector<Qubit>{target}, qc::Reset);
         }
-        void reset(const std::vector<dd::Qubit>& targets) {
+        void reset(const std::vector<Qubit>& targets) {
             checkQubitRange(targets);
             emplace_back<NonUnitaryOperation>(getNqubits(), targets, qc::Reset);
         }
 
-        void barrier(dd::Qubit target) {
+        void barrier(Qubit target) {
             checkQubitRange(target);
-            emplace_back<NonUnitaryOperation>(getNqubits(), std::vector<dd::Qubit>{target}, qc::Barrier);
+            emplace_back<NonUnitaryOperation>(getNqubits(), std::vector<Qubit>{target}, qc::Barrier);
         }
-        void barrier(const std::vector<dd::Qubit>& targets) {
+        void barrier(const std::vector<Qubit>& targets) {
             checkQubitRange(targets);
             emplace_back<NonUnitaryOperation>(getNqubits(), targets, qc::Barrier);
         }
 
-        void classicControlled(const OpType op, const dd::Qubit target, const std::pair<dd::Qubit, dd::QubitCount>& controlRegister, const unsigned int expectedValue = 1U, const dd::fp lambda = 0., const dd::fp phi = 0., const dd::fp theta = 0.) {
-            classicControlled(op, target, dd::Controls{}, controlRegister, expectedValue, lambda, phi, theta);
+        void classicControlled(const OpType op, const Qubit target, const ClassicalRegister& controlRegister, const std::uint64_t expectedValue = 1U, const fp lambda = 0., const fp phi = 0., const fp theta = 0.) {
+            classicControlled(op, target, Controls{}, controlRegister, expectedValue, lambda, phi, theta);
         }
-        void classicControlled(const OpType op, const dd::Qubit target, const dd::Control control, const std::pair<dd::Qubit, dd::QubitCount>& controlRegister, const unsigned int expectedValue = 1U, const dd::fp lambda = 0., const dd::fp phi = 0., const dd::fp theta = 0.) {
-            classicControlled(op, target, dd::Controls{control}, controlRegister, expectedValue, lambda, phi, theta);
+        void classicControlled(const OpType op, const Qubit target, const Control control, const ClassicalRegister& controlRegister, const std::uint64_t expectedValue = 1U, const fp lambda = 0., const fp phi = 0., const fp theta = 0.) {
+            classicControlled(op, target, Controls{control}, controlRegister, expectedValue, lambda, phi, theta);
         }
-        void classicControlled(const OpType op, const dd::Qubit target, const dd::Controls& controls, const std::pair<dd::Qubit, dd::QubitCount>& controlRegister, const unsigned int expectedValue = 1U, const dd::fp lambda = 0., const dd::fp phi = 0., const dd::fp theta = 0.) {
+        void classicControlled(const OpType op, const Qubit target, const Controls& controls, const ClassicalRegister& controlRegister, const std::uint64_t expectedValue = 1U, const fp lambda = 0., const fp phi = 0., const fp theta = 0.) {
             checkQubitRange(target, controls);
             std::unique_ptr<Operation> gate = std::make_unique<StandardOperation>(getNqubits(), controls, target, op, lambda, phi, theta);
             emplace_back<ClassicControlledOperation>(std::move(gate), controlRegister, expectedValue);
@@ -660,7 +659,7 @@ namespace qc {
         // append measurements to the end of the circuit according to the tracked output permutation
         void appendMeasurementsAccordingToOutputPermutation(const std::string& registerName = DEFAULT_CREG);
         // search for current position of target value in map and afterwards exchange it with the value at new position
-        static void findAndSWAP(dd::Qubit targetValue, dd::Qubit newPosition, Permutation& map) {
+        static void findAndSWAP(Qubit targetValue, Qubit newPosition, Permutation& map) {
             for (const auto& q: map) {
                 if (q.second == targetValue) {
                     std::swap(map.at(newPosition), map.at(q.first));
@@ -670,23 +669,23 @@ namespace qc {
         }
 
         // this function augments a given circuit by additional registers
-        void addQubitRegister(std::size_t, const char* reg_name = DEFAULT_QREG);
-        void addClassicalRegister(std::size_t nc, const char* reg_name = DEFAULT_CREG);
-        void addAncillaryRegister(std::size_t nq, const char* reg_name = DEFAULT_ANCREG);
+        void addQubitRegister(std::size_t, const char* regName = DEFAULT_QREG);
+        void addClassicalRegister(std::size_t nc, const char* regName = DEFAULT_CREG);
+        void addAncillaryRegister(std::size_t nq, const char* regName = DEFAULT_ANCREG);
         // a function to combine all quantum registers (qregs and ancregs) into a single register (useful for circuits mapped to a device)
         void unifyQuantumRegisters(const std::string& regName = DEFAULT_QREG);
 
         // removes a specific logical qubit and returns the index of the physical qubit in the initial layout
         // as well as the index of the removed physical qubit's output permutation
         // i.e., initialLayout[physical_qubit] = logical_qubit and outputPermutation[physicalQubit] = output_qubit
-        std::pair<dd::Qubit, dd::Qubit> removeQubit(dd::Qubit logical_qubit_index);
+        std::pair<Qubit, std::optional<Qubit>> removeQubit(Qubit logicalQubitIndex);
 
         // adds physical qubit as ancillary qubit and gives it the appropriate output mapping
-        void addAncillaryQubit(dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index);
+        void addAncillaryQubit(Qubit physicalQubitIndex, std::optional<Qubit> outputQubitIndex);
         // try to add logical qubit to circuit and assign it to physical qubit with certain output permutation value
-        void addQubit(dd::Qubit logical_qubit_index, dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index);
+        void addQubit(Qubit logicalQubitIndex, Qubit physicalQubitIndex, std::optional<Qubit> outputQubitIndex);
 
-        void updateMaxControls(dd::QubitCount ncontrols) {
+        void updateMaxControls(const std::size_t ncontrols) {
             max_controls = std::max(ncontrols, max_controls);
         }
 
@@ -729,7 +728,6 @@ namespace qc {
         }
         virtual void dump(std::ostream&& of, Format format);
         virtual void dumpOpenQASM(std::ostream& of);
-        virtual void dumpTensorNetwork(std::ostream& of) const;
 
         // this convenience method allows to turn a circuit into a compound operation.
         std::unique_ptr<CompoundOperation> asCompoundOperation() {
@@ -780,18 +778,18 @@ namespace qc {
         [[nodiscard]] auto crend() const noexcept { return ops.crend(); }
 
         // Capacity (pass-through)
-        [[nodiscard]] bool   empty() const noexcept { return ops.empty(); }
-        [[nodiscard]] size_t size() const noexcept { return ops.size(); }
-        [[nodiscard]] size_t max_size() const noexcept { return ops.max_size(); }
-        [[nodiscard]] size_t capacity() const noexcept { return ops.capacity(); }
+        [[nodiscard]] bool        empty() const noexcept { return ops.empty(); }
+        [[nodiscard]] std::size_t size() const noexcept { return ops.size(); }
+        [[nodiscard]] std::size_t max_size() const noexcept { return ops.max_size(); }
+        [[nodiscard]] std::size_t capacity() const noexcept { return ops.capacity(); }
 
-        void reserve(size_t new_cap) { ops.reserve(new_cap); }
+        void reserve(const std::size_t newCap) { ops.reserve(newCap); }
         void shrink_to_fit() { ops.shrink_to_fit(); }
 
         // Modifiers (pass-through)
         void     clear() noexcept { ops.clear(); }
         void     pop_back() { return ops.pop_back(); }
-        void     resize(size_t count) { ops.resize(count); }
+        void     resize(std::size_t count) { ops.resize(count); }
         iterator erase(const_iterator pos) { return ops.erase(pos); }
         iterator erase(const_iterator first, const_iterator last) { return ops.erase(first, last); }
 
@@ -822,7 +820,7 @@ namespace qc {
         template<class T>
         iterator insert(const_iterator pos, T&& op) { return ops.insert(pos, std::forward<T>(op)); }
 
-        [[nodiscard]] const auto& at(std::size_t i) const { return ops.at(i); }
+        [[nodiscard]] const auto& at(const std::size_t i) const { return ops.at(i); }
         [[nodiscard]] const auto& front() const { return ops.front(); }
         [[nodiscard]] const auto& back() const { return ops.back(); }
     };

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -42,10 +42,10 @@ namespace qc {
 
     protected:
         std::vector<std::unique_ptr<Operation>> ops{};
-        std::size_t                             nqubits      = 0;
-        std::size_t                             nclassics    = 0;
-        std::size_t                             nancillae    = 0;
-        std::size_t                             max_controls = 0;
+        std::size_t                             nqubits     = 0;
+        std::size_t                             nclassics   = 0;
+        std::size_t                             nancillae   = 0;
+        std::size_t                             maxControls = 0;
         std::string                             name;
 
         // register names are used as keys, while the values are `{startIndex, length}` pairs
@@ -218,7 +218,7 @@ namespace qc {
             qc.nqubits           = nqubits;
             qc.nclassics         = nclassics;
             qc.nancillae         = nancillae;
-            qc.max_controls      = max_controls;
+            qc.maxControls       = maxControls;
             qc.name              = name;
             qc.qregs             = qregs;
             qc.cregs             = cregs;
@@ -686,7 +686,7 @@ namespace qc {
         void addQubit(Qubit logicalQubitIndex, Qubit physicalQubitIndex, std::optional<Qubit> outputQubitIndex);
 
         void updateMaxControls(const std::size_t ncontrols) {
-            max_controls = std::max(ncontrols, max_controls);
+            maxControls = std::max(ncontrols, maxControls);
         }
 
         void instantiate(const VariableAssignment& assignment);

--- a/include/algorithms/BernsteinVazirani.hpp
+++ b/include/algorithms/BernsteinVazirani.hpp
@@ -8,19 +8,17 @@
 #include <QuantumComputation.hpp>
 #include <bitset>
 
-using namespace dd::literals;
-
 namespace qc {
     class BernsteinVazirani: public QuantumComputation {
     public:
-        BitString      s        = 0;
-        dd::QubitCount bitwidth = 1;
-        bool           dynamic  = false;
-        std::string    expected{};
+        BitString   s        = 0;
+        std::size_t bitwidth = 1;
+        bool        dynamic  = false;
+        std::string expected{};
 
         explicit BernsteinVazirani(const BitString& s, bool dynamic = false);
-        explicit BernsteinVazirani(dd::QubitCount nq, bool dynamic = false);
-        BernsteinVazirani(const BitString& s, dd::QubitCount nq, bool dynamic = false);
+        explicit BernsteinVazirani(std::size_t nq, bool dynamic = false);
+        BernsteinVazirani(const BitString& s, std::size_t nq, bool dynamic = false);
 
         std::ostream& printStatistics(std::ostream& os) const override;
 

--- a/include/algorithms/Entanglement.hpp
+++ b/include/algorithms/Entanglement.hpp
@@ -10,6 +10,6 @@
 namespace qc {
     class Entanglement: public QuantumComputation {
     public:
-        explicit Entanglement(dd::QubitCount nq);
+        explicit Entanglement(std::size_t nq);
     };
 } // namespace qc

--- a/include/algorithms/GoogleRandomCircuitSampling.hpp
+++ b/include/algorithms/GoogleRandomCircuitSampling.hpp
@@ -20,9 +20,9 @@ namespace qc {
 
         explicit GoogleRandomCircuitSampling(const std::string& filename);
 
-        GoogleRandomCircuitSampling(const std::string& pathPrefix, unsigned short device, unsigned short depth, unsigned short instance);
+        GoogleRandomCircuitSampling(const std::string& pathPrefix, std::uint16_t device, std::uint16_t depth, std::uint16_t instance);
 
-        GoogleRandomCircuitSampling(const std::string& pathPrefix, unsigned short x, unsigned short y, unsigned short depth, unsigned short instance);
+        GoogleRandomCircuitSampling(const std::string& pathPrefix, std::uint16_t x, std::uint16_t y, std::uint16_t depth, std::uint16_t instance);
 
         void importGRCS(const std::string& filename);
 
@@ -32,7 +32,7 @@ namespace qc {
 
         std::ostream& printStatistics(std::ostream& os) const override;
 
-        void removeCycles(unsigned short ncycles) {
+        void removeCycles(std::uint16_t ncycles) {
             if (ncycles > cycles.size() - 2) {
                 std::stringstream ss{};
                 ss << "Cannot remove " << ncycles << " cycles out of a circuit containing 1+" << cycles.size() - 2 << "+1 cycles.";

--- a/include/algorithms/Grover.hpp
+++ b/include/algorithms/Grover.hpp
@@ -14,13 +14,13 @@
 namespace qc {
     class Grover: public QuantumComputation {
     public:
-        std::size_t    seed        = 0;
-        BitString      targetValue = 0;
-        std::size_t    iterations  = 1;
-        std::string    expected{};
-        dd::QubitCount nDataQubits{};
+        std::size_t seed        = 0;
+        BitString   targetValue = 0;
+        std::size_t iterations  = 1;
+        std::string expected{};
+        std::size_t nDataQubits{};
 
-        explicit Grover(dd::QubitCount nq, std::size_t seed = 0);
+        explicit Grover(std::size_t nq, std::size_t seed = 0);
 
         void setup(QuantumComputation& qc) const;
 
@@ -28,7 +28,7 @@ namespace qc {
 
         void diffusion(QuantumComputation& qc) const;
 
-        void full_grover(QuantumComputation& qc) const;
+        void fullGrover(QuantumComputation& qc) const;
 
         std::ostream& printStatistics(std::ostream& os) const override;
     };

--- a/include/algorithms/QFT.hpp
+++ b/include/algorithms/QFT.hpp
@@ -10,13 +10,13 @@
 namespace qc {
     class QFT: public QuantumComputation {
     public:
-        explicit QFT(dd::QubitCount nq, bool includeMeasurements = true, bool dynamic = false);
+        explicit QFT(std::size_t nq, bool includeMeasurements = true, bool dynamic = false);
 
         std::ostream& printStatistics(std::ostream& os) const override;
 
-        const dd::QubitCount precision{};
-        const bool           includeMeasurements;
-        const bool           dynamic;
+        const std::size_t precision{};
+        const bool        includeMeasurements;
+        const bool        dynamic;
 
     protected:
         void createCircuit();

--- a/include/algorithms/QPE.hpp
+++ b/include/algorithms/QPE.hpp
@@ -7,17 +7,15 @@
 
 #include "QuantumComputation.hpp"
 
-using namespace dd::literals;
-
 namespace qc {
     class QPE: public QuantumComputation {
     public:
-        dd::fp               lambda = 0.;
-        const dd::QubitCount precision;
-        const bool           iterative;
+        fp                lambda = 0.;
+        const std::size_t precision;
+        const bool        iterative;
 
-        explicit QPE(dd::QubitCount nq, bool exact = true, bool iterative = false);
-        QPE(dd::fp lambda, dd::QubitCount precision, bool iterativ = false);
+        explicit QPE(std::size_t nq, bool exact = true, bool iterative = false);
+        QPE(fp lambda, std::size_t precision, bool iterativ = false);
 
         std::ostream& printStatistics(std::ostream& os) const override;
 

--- a/include/algorithms/RandomCliffordCircuit.hpp
+++ b/include/algorithms/RandomCliffordCircuit.hpp
@@ -12,16 +12,16 @@
 namespace qc {
     class RandomCliffordCircuit: public QuantumComputation {
     protected:
-        std::function<std::uint_fast16_t()> cliffordGenerator;
+        std::function<std::uint16_t()> cliffordGenerator;
 
-        void append1QClifford(std::uint_fast16_t idx, dd::Qubit target);
-        void append2QClifford(std::uint_fast16_t, dd::Qubit control, dd::Qubit target);
+        void append1QClifford(std::uint16_t idx, Qubit target);
+        void append2QClifford(std::uint16_t, Qubit control, Qubit target);
 
     public:
         std::size_t depth = 1;
         std::size_t seed  = 0;
 
-        explicit RandomCliffordCircuit(dd::QubitCount nq, std::size_t depth = 1, std::size_t seed = 0);
+        explicit RandomCliffordCircuit(std::size_t nq, std::size_t depth = 1, std::size_t seed = 0);
 
         std::ostream& printStatistics(std::ostream& os) const override;
     };

--- a/include/dd/FunctionalityConstruction.hpp
+++ b/include/dd/FunctionalityConstruction.hpp
@@ -220,4 +220,21 @@ namespace dd {
         return e;
     }
 
+    inline void dumpTensorNetwork(std::ostream& of, const QuantumComputation& qc) {
+        of << "{\"tensors\": [\n";
+
+        // initialize an index for every qubit
+        auto        inds    = std::vector<std::size_t>(qc.getNqubits(), 0U);
+        std::size_t gateIdx = 0U;
+        auto        dd      = std::make_unique<dd::Package<>>(qc.getNqubits());
+        for (const auto& op: qc) {
+            const auto type = op->getType();
+            if (op != qc.front() && (type != Measure && type != Barrier && type != ShowProbabilities && type != Snapshot)) {
+                of << ",\n";
+            }
+            dumpTensor(op.get(), of, inds, gateIdx, dd);
+        }
+        of << "\n]}\n";
+    }
+
 } // namespace dd

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -10,28 +10,28 @@
 namespace qc {
 
     class ClassicControlledOperation final: public Operation {
-    protected:
-        std::unique_ptr<Operation>           op;
-        std::pair<dd::Qubit, dd::QubitCount> controlRegister{};
-        unsigned int                         expectedValue = 1U;
+    private:
+        std::unique_ptr<Operation> op;
+        ClassicalRegister          controlRegister{};
+        std::uint64_t              expectedValue = 1U;
 
     public:
         // Applies operation `_op` if the creg starting at index `control` has the expected value
-        ClassicControlledOperation(std::unique_ptr<qc::Operation>& _op, const std::pair<dd::Qubit, dd::QubitCount>& controlRegister, unsigned int expectedValue = 1U):
-            op(std::move(_op)), controlRegister(controlRegister), expectedValue(expectedValue) {
-            nqubits = op->getNqubits();
+        ClassicControlledOperation(std::unique_ptr<qc::Operation>& op, const ClassicalRegister& controlRegister, std::uint64_t expectedValue = 1U):
+            op(std::move(op)), controlRegister(controlRegister), expectedValue(expectedValue) {
+            nqubits = this->op->getNqubits();
             name[0] = 'c';
             name[1] = '_';
-            std::strcpy(name + 2, op->getName());
-            parameter[0] = controlRegister.first;
-            parameter[1] = controlRegister.second;
-            parameter[2] = expectedValue;
+            std::strcpy(name + 2, this->op->getName());
+            parameter[0] = static_cast<fp>(controlRegister.first);
+            parameter[1] = static_cast<fp>(controlRegister.second);
+            parameter[2] = static_cast<fp>(expectedValue);
             type         = ClassicControlled;
         }
 
         [[nodiscard]] std::unique_ptr<Operation> clone() const override {
-            auto op_cloned = op->clone();
-            return std::make_unique<ClassicControlledOperation>(op_cloned, controlRegister, expectedValue);
+            auto opCloned = op->clone();
+            return std::make_unique<ClassicControlledOperation>(opCloned, controlRegister, expectedValue);
         }
 
         [[nodiscard]] auto getControlRegister() const {
@@ -46,7 +46,7 @@ namespace qc {
             return op.get();
         }
 
-        void setNqubits(dd::QubitCount nq) override {
+        void setNqubits(std::size_t nq) override {
             nqubits = nq;
             op->setNqubits(nq);
         }
@@ -63,11 +63,11 @@ namespace qc {
             return op->getNtargets();
         }
 
-        [[nodiscard]] const dd::Controls& getControls() const override {
+        [[nodiscard]] const Controls& getControls() const override {
             return op->getControls();
         }
 
-        dd::Controls& getControls() override {
+        Controls& getControls() override {
             return op->getControls();
         }
 
@@ -83,7 +83,7 @@ namespace qc {
             return true;
         }
 
-        [[nodiscard]] bool actsOn(dd::Qubit i) const override {
+        [[nodiscard]] bool actsOn(Qubit i) const override {
             return op->actsOn(i);
         }
 
@@ -98,11 +98,8 @@ namespace qc {
                 }
 
                 return op->equals(*classic->op, perm1, perm2);
-
-            } else {
-                return false;
             }
-            return Operation::equals(operation, perm1, perm2);
+            return false;
         }
         [[nodiscard]] bool equals(const Operation& operation) const override {
             return equals(operation, {}, {});

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -10,32 +10,32 @@
 namespace qc {
 
     class CompoundOperation final: public Operation {
-    protected:
+    private:
         std::vector<std::unique_ptr<Operation>> ops{};
 
     public:
-        explicit CompoundOperation(dd::QubitCount nq) {
+        explicit CompoundOperation(const std::size_t nq) {
             std::strcpy(name, "Compound operation:");
             nqubits = nq;
             type    = Compound;
         }
 
-        explicit CompoundOperation(dd::QubitCount nq, std::vector<std::unique_ptr<Operation>>&& operations):
+        explicit CompoundOperation(const std::size_t nq, std::vector<std::unique_ptr<Operation>>&& operations):
             CompoundOperation(nq) {
             ops = std::move(operations);
         }
 
         [[nodiscard]] std::unique_ptr<Operation> clone() const override {
-            auto cloned_co = std::make_unique<CompoundOperation>(nqubits);
-            cloned_co->reserve(ops.size());
+            auto clonedCo = std::make_unique<CompoundOperation>(nqubits);
+            clonedCo->reserve(ops.size());
 
-            for (auto& op: ops) {
-                cloned_co->ops.emplace_back<>(op->clone());
+            for (const auto& op: ops) {
+                clonedCo->ops.emplace_back<>(op->clone());
             }
-            return cloned_co;
+            return clonedCo;
         }
 
-        void setNqubits(dd::QubitCount nq) override {
+        void setNqubits(const std::size_t nq) override {
             nqubits = nq;
             for (auto& op: ops) {
                 op->setNqubits(nq);
@@ -68,9 +68,8 @@ namespace qc {
                     ++it;
                 }
                 return true;
-            } else {
-                return false;
             }
+            return false;
         }
         [[nodiscard]] bool equals(const Operation& operation) const override {
             return equals(operation, {}, {});
@@ -98,7 +97,7 @@ namespace qc {
             return os;
         }
 
-        [[nodiscard]] bool actsOn(dd::Qubit i) const override {
+        [[nodiscard]] bool actsOn(const Qubit i) const override {
             return std::any_of(ops.cbegin(), ops.cend(), [&i](const auto& op) { return op->actsOn(i); });
         }
 
@@ -138,7 +137,7 @@ namespace qc {
         [[nodiscard]] std::size_t max_size() const noexcept { return ops.max_size(); }
         [[nodiscard]] std::size_t capacity() const noexcept { return ops.capacity(); }
 
-        void reserve(std::size_t new_cap) { ops.reserve(new_cap); }
+        void reserve(std::size_t newCap) { ops.reserve(newCap); }
         void shrink_to_fit() { ops.shrink_to_fit(); }
 
         // Modifiers (pass-through)
@@ -168,8 +167,8 @@ namespace qc {
 
         std::vector<std::unique_ptr<Operation>>& getOps() { return ops; }
 
-        [[nodiscard]] std::set<dd::Qubit> getUsedQubits() const override {
-            std::set<dd::Qubit> usedQubits{};
+        [[nodiscard]] std::set<Qubit> getUsedQubits() const override {
+            std::set<Qubit> usedQubits{};
             for (const auto& op: ops) {
                 usedQubits.merge(op->getUsedQubits());
             }

--- a/include/operations/Control.hpp
+++ b/include/operations/Control.hpp
@@ -1,0 +1,61 @@
+/*
+* This file is part of MQT QFR library which is released under the MIT license.
+* See file README.md or go to https://www.cda.cit.tum.de/research/quantum/ for more information.
+*/
+
+#pragma once
+
+#include "Definitions.hpp"
+
+#include <set>
+
+namespace qc {
+    struct Control {
+        enum class Type : bool { Pos = true,
+                                 Neg = false };
+
+        Qubit qubit{};
+        Type  type = Type::Pos;
+    };
+
+    inline bool operator<(const Control& lhs, const Control& rhs) {
+        return lhs.qubit < rhs.qubit || (lhs.qubit == rhs.qubit && lhs.type < rhs.type);
+    }
+
+    inline bool operator==(const Control& lhs, const Control& rhs) {
+        return lhs.qubit == rhs.qubit && lhs.type == rhs.type;
+    }
+
+    inline bool operator!=(const Control& lhs, const Control& rhs) {
+        return !(lhs == rhs);
+    }
+
+    // this allows a set of controls to be indexed by a `Qubit`
+    struct CompareControl {
+        using is_transparent [[maybe_unused]] = void;
+
+        inline bool operator()(const Control& lhs, const Control& rhs) const {
+            return lhs < rhs;
+        }
+
+        inline bool operator()(Qubit lhs, const Control& rhs) const {
+            return lhs < rhs.qubit;
+        }
+
+        inline bool operator()(const Control& lhs, Qubit rhs) const {
+            return lhs.qubit < rhs;
+        }
+    };
+    using Controls = std::set<Control, CompareControl>;
+
+    inline namespace literals {
+        // NOLINTNEXTLINE(google-runtime-int) User-defined literals require unsigned long long int
+        inline Control operator""_pc(unsigned long long int q) {
+            return {static_cast<Qubit>(q)};
+        }
+        // NOLINTNEXTLINE(google-runtime-int) User-defined literals require unsigned long long int
+        inline Control operator""_nc(unsigned long long int q) {
+            return {static_cast<Qubit>(q), Control::Type::Neg};
+        }
+    } // namespace literals
+} // namespace qc

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -11,40 +11,41 @@ namespace qc {
 
     class NonUnitaryOperation final: public Operation {
     protected:
-        std::vector<dd::Qubit>   qubits{};   // vector for the qubits to measure (necessary since std::set does not preserve the order of inserted elements)
-        std::vector<std::size_t> classics{}; // vector for the classical bits to measure into
+        std::vector<Qubit> qubits{};   // vector for the qubits to measure (necessary since std::set does not preserve the order of inserted elements)
+        std::vector<Bit>   classics{}; // vector for the classical bits to measure into
 
-        std::ostream& printNonUnitary(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c = {}, const Permutation& permutation = {}) const;
-        void          printMeasurement(std::ostream& os, const std::vector<dd::Qubit>& q, const std::vector<std::size_t>& c, const Permutation& permutation) const;
-        void          printResetBarrierOrSnapshot(std::ostream& os, const std::vector<dd::Qubit>& q, const Permutation& permutation) const;
+        std::ostream& printNonUnitary(std::ostream& os, const std::vector<Qubit>& q, const std::vector<Bit>& c = {}, const Permutation& permutation = {}) const;
+        void          printMeasurement(std::ostream& os, const std::vector<Qubit>& q, const std::vector<Bit>& c, const Permutation& permutation) const;
+        void          printResetBarrierOrSnapshot(std::ostream& os, const std::vector<Qubit>& q, const Permutation& permutation) const;
 
     public:
         // Measurement constructor
-        NonUnitaryOperation(dd::QubitCount nq, std::vector<dd::Qubit> qubitRegister, std::vector<std::size_t> classicalRegister);
-        NonUnitaryOperation(dd::QubitCount nq, dd::Qubit qubit, std::size_t cbit);
+        NonUnitaryOperation(std::size_t nq, std::vector<Qubit> qubitRegister, std::vector<Bit> classicalRegister);
+        NonUnitaryOperation(std::size_t nq, Qubit qubit, Bit cbit);
 
         // Snapshot constructor
-        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, std::size_t n);
+        NonUnitaryOperation(std::size_t nq, const std::vector<Qubit>& qubitRegister, std::size_t n);
 
         // ShowProbabilities constructor
-        explicit NonUnitaryOperation(const dd::QubitCount nq) {
+        explicit NonUnitaryOperation(const std::size_t nq) {
             nqubits = nq;
             type    = ShowProbabilities;
         }
 
         // General constructor
-        NonUnitaryOperation(dd::QubitCount nq, const std::vector<dd::Qubit>& qubitRegister, OpType op = Reset);
+        NonUnitaryOperation(std::size_t nq, const std::vector<Qubit>& qubitRegister, OpType op = Reset);
 
         [[nodiscard]] std::unique_ptr<Operation> clone() const override {
             if (getType() == qc::Measure) {
                 return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(), getClassics());
-            } else if (getType() == qc::Snapshot) {
-                return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(), getParameter().at(0));
-            } else if (getType() == qc::ShowProbabilities) {
-                return std::make_unique<NonUnitaryOperation>(getNqubits());
-            } else {
-                return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(), getType());
             }
+            if (getType() == qc::Snapshot) {
+                return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(), getParameter().at(0));
+            }
+            if (getType() == qc::ShowProbabilities) {
+                return std::make_unique<NonUnitaryOperation>(getNqubits());
+            }
+            return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(), getType());
         }
 
         [[nodiscard]] bool isUnitary() const override {
@@ -56,32 +57,34 @@ namespace qc {
         }
 
         [[nodiscard]] const Targets& getTargets() const override {
-            if (type == Measure)
+            if (type == Measure) {
                 return qubits;
-            else
+            } else {
                 return targets;
+            }
         }
         Targets& getTargets() override {
-            if (type == Measure)
+            if (type == Measure) {
                 return qubits;
-            else
+            } else {
                 return targets;
+            }
         }
-        [[nodiscard]] size_t getNtargets() const override {
+        [[nodiscard]] std::size_t getNtargets() const override {
             return getTargets().size();
         }
 
-        [[nodiscard]] const std::vector<std::size_t>& getClassics() const {
+        [[nodiscard]] const std::vector<Bit>& getClassics() const {
             return classics;
         }
-        std::vector<std::size_t>& getClassics() {
+        std::vector<Bit>& getClassics() {
             return classics;
         }
         [[nodiscard]] size_t getNclassics() const {
             return classics.size();
         }
 
-        [[nodiscard]] bool actsOn(dd::Qubit i) const override;
+        [[nodiscard]] bool actsOn(Qubit i) const override;
 
         void addDepthContribution(std::vector<std::size_t>& depths) const override;
 
@@ -93,23 +96,21 @@ namespace qc {
         std::ostream& print(std::ostream& os) const override {
             if (type == Measure) {
                 return printNonUnitary(os, qubits, classics);
-            } else {
-                return printNonUnitary(os, targets);
             }
+            return printNonUnitary(os, targets);
         }
         std::ostream& print(std::ostream& os, const Permutation& permutation) const override {
             if (type == Measure) {
                 return printNonUnitary(os, qubits, classics, permutation);
-            } else {
-                return printNonUnitary(os, targets, {}, permutation);
             }
+            return printNonUnitary(os, targets, {}, permutation);
         }
 
         void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, const RegisterNames& creg) const override;
 
-        [[nodiscard]] std::set<dd::Qubit> getUsedQubits() const override {
+        [[nodiscard]] std::set<Qubit> getUsedQubits() const override {
             const auto& targets = getTargets();
-            return std::set<dd::Qubit>{targets.begin(), targets.end()};
+            return {targets.begin(), targets.end()};
         }
     };
 } // namespace qc

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -7,7 +7,7 @@
 
 #include "Definitions.hpp"
 #include "OpType.hpp"
-#include "dd/ComplexValue.hpp"
+#include "Permutation.hpp"
 
 #include <array>
 #include <cstring>
@@ -26,14 +26,14 @@ namespace qc {
 
     class Operation {
     protected:
-        dd::Controls                       controls{};
-        Targets                            targets{};
-        std::array<dd::fp, MAX_PARAMETERS> parameter{};
+        Controls                       controls{};
+        Targets                        targets{};
+        std::array<fp, MAX_PARAMETERS> parameter{};
 
-        dd::QubitCount nqubits    = 0;
-        dd::Qubit      startQubit = 0;
-        OpType         type       = None; // Op type
-        char           name[MAX_STRING_LENGTH]{};
+        std::size_t nqubits    = 0;
+        Qubit       startQubit = 0;
+        OpType      type       = None;
+        char        name[MAX_STRING_LENGTH]{};
 
         static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start, std::size_t end) {
             return !reg.empty() && reg[start].first == reg[end].first && (start == 0 || reg[start].first != reg[start - 1].first) && (end == reg.size() - 1 || reg[end].first != reg[end + 1].first);
@@ -65,24 +65,24 @@ namespace qc {
             return targets.size();
         }
 
-        [[nodiscard]] virtual const dd::Controls& getControls() const {
+        [[nodiscard]] virtual const Controls& getControls() const {
             return controls;
         }
-        virtual dd::Controls& getControls() {
+        virtual Controls& getControls() {
             return controls;
         }
         [[nodiscard]] virtual std::size_t getNcontrols() const {
             return controls.size();
         }
 
-        [[nodiscard]] dd::QubitCount getNqubits() const {
+        [[nodiscard]] std::size_t getNqubits() const {
             return nqubits;
         }
 
-        [[nodiscard]] const std::array<dd::fp, MAX_PARAMETERS>& getParameter() const {
+        [[nodiscard]] const std::array<fp, MAX_PARAMETERS>& getParameter() const {
             return parameter;
         }
-        std::array<dd::fp, MAX_PARAMETERS>& getParameter() {
+        std::array<fp, MAX_PARAMETERS>& getParameter() {
             return parameter;
         }
 
@@ -93,14 +93,14 @@ namespace qc {
             return type;
         }
 
-        [[nodiscard]] virtual dd::Qubit getStartingQubit() const {
+        [[nodiscard]] virtual Qubit getStartingQubit() const {
             return startQubit;
         }
 
-        [[nodiscard]] virtual std::set<dd::Qubit> getUsedQubits() const {
-            const auto&         opTargets  = getTargets();
-            const auto&         opControls = getControls();
-            std::set<dd::Qubit> usedQubits = {opTargets.begin(), opTargets.end()};
+        [[nodiscard]] virtual std::set<Qubit> getUsedQubits() const {
+            const auto&     opTargets  = getTargets();
+            const auto&     opControls = getControls();
+            std::set<Qubit> usedQubits = {opTargets.begin(), opTargets.end()};
             for (const auto& control: opControls) {
                 usedQubits.insert(control.qubit);
             }
@@ -108,7 +108,7 @@ namespace qc {
         }
 
         // Setter
-        virtual void setNqubits(dd::QubitCount nq) {
+        virtual void setNqubits(const std::size_t nq) {
             nqubits = nq;
         }
 
@@ -116,7 +116,7 @@ namespace qc {
             targets = t;
         }
 
-        virtual void setControls(const dd::Controls& c) {
+        virtual void setControls(const Controls& c) {
             controls = c;
         }
 
@@ -127,8 +127,8 @@ namespace qc {
             setName();
         }
 
-        virtual void setParameter(const std::array<dd::fp, MAX_PARAMETERS>& p) {
-            Operation::parameter = p;
+        virtual void setParameter(const std::array<fp, MAX_PARAMETERS>& p) {
+            parameter = p;
         }
 
         [[nodiscard]] inline virtual bool isUnitary() const {
@@ -159,16 +159,13 @@ namespace qc {
             return !controls.empty();
         }
 
-        [[nodiscard]] inline virtual bool actsOn(dd::Qubit i) const {
+        [[nodiscard]] inline virtual bool actsOn(Qubit i) const {
             for (const auto& t: targets) {
-                if (t == i)
+                if (t == i) {
                     return true;
+                }
             }
-
-            if (controls.count(i) > 0)
-                return true;
-
-            return false;
+            return controls.count(i) > 0;
         }
 
         virtual void addDepthContribution(std::vector<std::size_t>& depths) const;

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -29,8 +29,8 @@ namespace qc {
         static OpType parseU2(fp& lambda, fp& phi);
         static OpType parseU1(fp& lambda);
 
-        virtual void checkUgate();
-        void         setup(std::size_t nq, fp par0, fp par1, fp par2, Qubit startingQubit = 0);
+        void checkUgate();
+        void setup(std::size_t nq, fp par0, fp par1, fp par2, Qubit startingQubit = 0);
 
         void dumpOpenQASMSwap(std::ostream& of, const RegisterNames& qreg) const;
         void dumpOpenQASMiSwap(std::ostream& of, const RegisterNames& qreg) const;

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -10,27 +10,27 @@
 namespace qc {
     class StandardOperation: public Operation {
     protected:
-        static void checkInteger(dd::fp& ld) {
-            dd::fp nearest = std::nearbyint(ld);
+        static void checkInteger(fp& ld) {
+            const fp nearest = std::nearbyint(ld);
             if (std::abs(ld - nearest) < PARAMETER_TOLERANCE) {
                 ld = nearest;
             }
         }
 
-        static void checkFractionPi(dd::fp& ld) {
-            dd::fp div     = dd::PI / ld;
-            dd::fp nearest = std::nearbyint(div);
+        static void checkFractionPi(fp& ld) {
+            const fp div     = PI / ld;
+            const fp nearest = std::nearbyint(div);
             if (std::abs(div - nearest) < PARAMETER_TOLERANCE) {
-                ld = dd::PI / nearest;
+                ld = PI / nearest;
             }
         }
 
-        static OpType parseU3(dd::fp& lambda, dd::fp& phi, dd::fp& theta);
-        static OpType parseU2(dd::fp& lambda, dd::fp& phi);
-        static OpType parseU1(dd::fp& lambda);
+        static OpType parseU3(fp& lambda, fp& phi, fp& theta);
+        static OpType parseU2(fp& lambda, fp& phi);
+        static OpType parseU1(fp& lambda);
 
-        void checkUgate();
-        void setup(dd::QubitCount nq, dd::fp par0, dd::fp par1, dd::fp par2, dd::Qubit startingQubit = 0);
+        virtual void checkUgate();
+        void         setup(std::size_t nq, fp par0, fp par1, fp par2, Qubit startingQubit = 0);
 
         void dumpOpenQASMSwap(std::ostream& of, const RegisterNames& qreg) const;
         void dumpOpenQASMiSwap(std::ostream& of, const RegisterNames& qreg) const;
@@ -40,20 +40,20 @@ namespace qc {
         StandardOperation() = default;
 
         // Standard Constructors
-        StandardOperation(dd::QubitCount nq, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
-        StandardOperation(dd::QubitCount nq, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, Qubit target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, const Targets& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
 
-        StandardOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
-        StandardOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, Control control, Qubit target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, Control control, const Targets& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
 
-        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
-        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, const Controls& controls, Qubit target, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, const Controls& controls, const Targets& targets, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
 
         // MCT Constructor
-        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, dd::Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, const Controls& controls, Qubit target, Qubit startingQubit = 0);
 
         // MCF (cSWAP), Peres, paramterized two target Constructor
-        StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, OpType g, dd::fp lambda = 0., dd::fp phi = 0., dd::fp theta = 0., dd::Qubit startingQubit = 0);
+        StandardOperation(std::size_t nq, const Controls& controls, Qubit target0, Qubit target1, OpType g, fp lambda = 0., fp phi = 0., fp theta = 0., Qubit startingQubit = 0);
 
         [[nodiscard]] std::unique_ptr<Operation> clone() const override {
             return std::make_unique<StandardOperation>(getNqubits(), getControls(), getTargets(), getType(), getParameter().at(0), getParameter().at(1), getParameter().at(2), getStartingQubit());

--- a/include/operations/SymbolicOperation.hpp
+++ b/include/operations/SymbolicOperation.hpp
@@ -23,25 +23,25 @@ namespace qc {
     protected:
         std::array<std::optional<Symbolic>, MAX_PARAMETERS> symbolicParameter{};
 
-        static OpType parseU3(const Symbolic& lambda, dd::fp& phi, dd::fp& theta);
-        static OpType parseU3(dd::fp& lambda, const Symbolic& phi, dd::fp& theta);
-        static OpType parseU3(dd::fp& lambda, dd::fp& phi, const Symbolic& theta);
-        static OpType parseU3(const Symbolic& lambda, const Symbolic& phi, dd::fp& theta);
-        static OpType parseU3(const Symbolic& lambda, dd::fp& phi, const Symbolic& theta);
-        static OpType parseU3(dd::fp& lambda, const Symbolic& phi, const Symbolic& theta);
+        static OpType parseU3(const Symbolic& lambda, fp& phi, fp& theta);
+        static OpType parseU3(fp& lambda, const Symbolic& phi, fp& theta);
+        static OpType parseU3(fp& lambda, fp& phi, const Symbolic& theta);
+        static OpType parseU3(const Symbolic& lambda, const Symbolic& phi, fp& theta);
+        static OpType parseU3(const Symbolic& lambda, fp& phi, const Symbolic& theta);
+        static OpType parseU3(fp& lambda, const Symbolic& phi, const Symbolic& theta);
 
         static OpType parseU2(const Symbolic& lambda, const Symbolic& phi);
-        static OpType parseU2(const Symbolic& lambda, dd::fp& phi);
-        static OpType parseU2(dd::fp& lambda, const Symbolic& phi);
+        static OpType parseU2(const Symbolic& lambda, fp& phi);
+        static OpType parseU2(fp& lambda, const Symbolic& phi);
 
         static OpType parseU1(const Symbolic& lambda);
 
-        void checkUgate();
+        void checkUgate() override;
 
-        void storeSymbolOrNumber(const SymbolOrNumber& param, const std::size_t i);
+        void storeSymbolOrNumber(const SymbolOrNumber& param, std::size_t i);
 
         [[nodiscard]] bool isSymbolicParameter(const std::size_t i) const {
-            return symbolicParameter[i].has_value();
+            return symbolicParameter.at(i).has_value();
         }
 
         static bool isSymbol(const SymbolOrNumber& param) {
@@ -52,39 +52,40 @@ namespace qc {
             return std::get<Symbolic>(param);
         }
 
-        static dd::fp& getNumber(SymbolOrNumber& param) {
-            return std::get<dd::fp>(param);
+        static fp& getNumber(SymbolOrNumber& param) {
+            return std::get<fp>(param);
         }
 
-        void setup(dd::QubitCount nq, const SymbolOrNumber& par0, const SymbolOrNumber& par1, const SymbolOrNumber& par2, dd::Qubit startingQubit = 0);
+        void setup(std::size_t nq, const SymbolOrNumber& par0, const SymbolOrNumber& par1, const SymbolOrNumber& par2, Qubit startingQubit = 0);
 
-        [[nodiscard]] static dd::fp getInstantiation(const SymbolOrNumber& symOrNum, const VariableAssignment& assignment);
+        [[nodiscard]] static fp getInstantiation(const SymbolOrNumber& symOrNum, const VariableAssignment& assignment);
 
     public:
         SymbolicOperation() = default;
 
         [[nodiscard]] SymbolOrNumber getParameter(const std::size_t i) const {
-            if (symbolicParameter[i].has_value())
-                return symbolicParameter[i].value();
-            return parameter[i];
+            if (symbolicParameter.at(i).has_value()) {
+                return symbolicParameter.at(i).value();
+            }
+            return parameter.at(i);
         }
 
         void setSymbolicParameter(const Symbolic& par, const std::size_t i) {
-            symbolicParameter[i] = par;
+            symbolicParameter.at(i) = par;
         }
 
         // Standard Constructors
-        SymbolicOperation(dd::QubitCount nq, dd::Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
-        SymbolicOperation(dd::QubitCount nq, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
 
-        SymbolicOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
-        SymbolicOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, Control control, Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, Control control, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
 
-        SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
-        SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, const Controls& controls, Qubit target, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, const Controls& controls, const Targets& targets, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
 
         // MCF (cSWAP), Peres, paramterized two target Constructor
-        SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, dd::Qubit startingQubit = 0);
+        SymbolicOperation(std::size_t nq, const Controls& controls, Qubit target0, Qubit target1, OpType g, const SymbolOrNumber& lambda = 0.0, const SymbolOrNumber& phi = 0.0, const SymbolOrNumber& theta = 0.0, Qubit startingQubit = 0);
 
         [[nodiscard]] std::unique_ptr<Operation> clone() const override {
             return std::make_unique<SymbolicOperation>(getNqubits(), getControls(), getTargets(), getType(), getParameter(0), getParameter(1), getParameter(2), getStartingQubit());

--- a/include/operations/SymbolicOperation.hpp
+++ b/include/operations/SymbolicOperation.hpp
@@ -36,7 +36,7 @@ namespace qc {
 
         static OpType parseU1(const Symbolic& lambda);
 
-        void checkUgate() override;
+        void checkSymbolicUgate();
 
         void storeSymbolOrNumber(const SymbolOrNumber& param, std::size_t i);
 

--- a/include/parsers/qasm_parser/Parser.hpp
+++ b/include/parsers/qasm_parser/Parser.hpp
@@ -55,13 +55,13 @@ namespace qasm {
                 power,
                 id
             };
-            dd::fp      num;
+            qc::fp      num;
             Kind        kind;
             Expr*       op1 = nullptr;
             Expr*       op2 = nullptr;
             std::string id;
 
-            explicit Expr(Kind kind, dd::fp num = 0., Expr* op1 = nullptr, Expr* op2 = nullptr, std::string id = ""):
+            explicit Expr(Kind kind, qc::fp num = 0., Expr* op1 = nullptr, Expr* op2 = nullptr, std::string id = ""):
                 num(num), kind(kind), op1(op1), op2(op2), id(std::move(id)) {}
             Expr(const Expr& expr):
                 num(expr.num), kind(expr.kind), id(expr.id) {
@@ -183,7 +183,7 @@ namespace qasm {
         Scanner*                  scanner;
         qc::QuantumRegisterMap&   qregs;
         qc::ClassicalRegisterMap& cregs;
-        dd::QubitCount            nqubits   = 0;
+        std::size_t               nqubits   = 0;
         std::size_t               nclassics = 0;
         qc::Permutation           initialLayout{};
         qc::Permutation           outputPermutation{};
@@ -196,9 +196,11 @@ namespace qasm {
         virtual ~Parser() {
             delete scanner;
 
-            for (auto& cGate: compoundGates)
-                for (auto& gate: cGate.second.gates)
+            for (auto& cGate: compoundGates) {
+                for (auto& gate: cGate.second.gates) {
                     delete gate;
+                }
+            }
         }
 
         void scan();

--- a/include/parsers/qasm_parser/Token.hpp
+++ b/include/parsers/qasm_parser/Token.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "dd/Definitions.hpp"
+#include "Definitions.hpp"
 
 #include <map>
 #include <string>
@@ -71,7 +71,7 @@ namespace qasm {
         int         line    = 0;
         int         col     = 0;
         int         val     = 0;
-        dd::fp      valReal = 0.0;
+        qc::fp      valReal = 0.0;
         std::string str;
 
         Token() = default;

--- a/mqt/qfr/CMakeLists.txt
+++ b/mqt/qfr/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(MQT::${PROJECT_NAME}_python ALIAS ${PROJECT_NAME}_python)
 
 # add pyqfr module
 pybind11_add_module(py${PROJECT_NAME} bindings.cpp)
-target_link_libraries(py${PROJECT_NAME} PUBLIC ${PROJECT_NAME} MQT::${PROJECT_NAME}_python
+target_link_libraries(py${PROJECT_NAME} PUBLIC MQT::${PROJECT_NAME}_dd MQT::${PROJECT_NAME}_python
                                                pybind11_json)
 target_compile_definitions(py${PROJECT_NAME} PRIVATE VERSION_INFO=${QFR_VERSION_INFO})
 enable_lto(py${PROJECT_NAME})

--- a/mqt/qfr/qiskit/QasmQobjExperiment.hpp
+++ b/mqt/qfr/qiskit/QasmQobjExperiment.hpp
@@ -9,17 +9,18 @@
 #include "pybind11/pybind11.h"
 
 namespace py = pybind11;
-using namespace pybind11::literals;
 
 #include "QuantumComputation.hpp"
 
 namespace qc::qiskit {
+    using namespace pybind11::literals;
+
     class QasmQobjExperiment {
     public:
         static void import(QuantumComputation& qc, const py::object& circ) {
             qc.reset();
 
-            py::object pyQasmQobjExperiment = py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
+            const py::object pyQasmQobjExperiment = py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
 
             if (!py::isinstance(circ, pyQasmQobjExperiment)) {
                 throw QFRException("[import] Python object needs to be a Qiskit QasmQobjExperiment");
@@ -30,7 +31,7 @@ namespace qc::qiskit {
 
             auto&& circQregs = header.attr("qreg_sizes");
             for (const auto qreg: circQregs) {
-                qc.addQubitRegister(qreg.cast<py::list>()[1].cast<dd::QubitCount>(), qreg.cast<py::list>()[0].cast<std::string>().c_str());
+                qc.addQubitRegister(qreg.cast<py::list>()[1].cast<std::size_t>(), qreg.cast<py::list>()[0].cast<std::string>().c_str());
             }
 
             auto&& circCregs = header.attr("creg_sizes");
@@ -48,33 +49,33 @@ namespace qc::qiskit {
             QuantumComputation qc{};
             import(qc, circ);
             std::ofstream ofs(filename);
-            qc.dump(ofs, qc::Tensor);
+            dd::dumpTensorNetwork(ofs, qc);
         }
 
     protected:
         static void emplaceInstruction(QuantumComputation& qc, const py::object& instruction) {
-            static const auto nativelySupportedGates = std::set<std::string>{"i", "id", "iden", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "p", "u1", "rx", "ry", "rz", "u2", "u", "u3", "cx", "cy", "cz", "cp", "cu1", "ch", "crx", "cry", "crz", "cu3", "ccx", "swap", "cswap", "iswap", "sx", "sxdg", "csx", "mcx", "mcx_gray", "mcx_recursive", "mcx_vchain", "mcphase", "mcrx", "mcry", "mcrz"};
+            static const auto NATIVELY_SUPPORTED_GATES = std::set<std::string>{"i", "id", "iden", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "p", "u1", "rx", "ry", "rz", "u2", "u", "u3", "cx", "cy", "cz", "cp", "cu1", "ch", "crx", "cry", "crz", "cu3", "ccx", "swap", "cswap", "iswap", "sx", "sxdg", "csx", "mcx", "mcx_gray", "mcx_recursive", "mcx_vchain", "mcphase", "mcrx", "mcry", "mcrz"};
 
             auto instructionName = instruction.attr("name").cast<std::string>();
             if (instructionName == "measure") {
-                auto qubit = instruction.attr("qubits").cast<py::list>()[0].cast<dd::Qubit>();
+                auto qubit = instruction.attr("qubits").cast<py::list>()[0].cast<Qubit>();
                 auto clbit = instruction.attr("memory").cast<py::list>()[0].cast<std::size_t>();
                 qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), qubit, clbit);
             } else if (instructionName == "barrier") {
                 Targets targets{};
                 for (const auto qubit: instruction.attr("qubits")) {
-                    auto target = qubit.cast<dd::Qubit>();
+                    auto target = qubit.cast<Qubit>();
                     targets.emplace_back(target);
                 }
                 qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), targets, Barrier);
             } else if (instructionName == "reset") {
                 Targets targets{};
                 for (const auto qubit: instruction.attr("qubits")) {
-                    auto target = qubit.cast<dd::Qubit>();
+                    auto target = qubit.cast<Qubit>();
                     targets.emplace_back(target);
                 }
                 qc.reset(targets);
-            } else if (nativelySupportedGates.count(instructionName)) {
+            } else if (NATIVELY_SUPPORTED_GATES.count(instructionName) != 0) {
                 auto&&   qubits = instruction.attr("qubits").cast<py::list>();
                 py::list params{};
                 // natively supported operations
@@ -131,9 +132,9 @@ namespace qc::qiskit {
                         addOperation(qc, X, qubitsCopy, params);
                     }
                 } else if (instructionName == "mcx_vchain") {
-                    auto        size       = qubits.size();
-                    std::size_t ncontrols  = (size + 1) / 2;
-                    auto        qubitsCopy = qubits.attr("copy")();
+                    auto              size       = qubits.size();
+                    const std::size_t ncontrols  = (size + 1) / 2;
+                    auto              qubitsCopy = qubits.attr("copy")();
                     // discard ancillaries
                     for (std::size_t i = 0; i < ncontrols - 2; ++i) {
                         qubitsCopy.attr("pop")();
@@ -146,51 +147,51 @@ namespace qc::qiskit {
         }
 
         static void addOperation(QuantumComputation& qc, OpType type, const py::list& qubits, const py::list& params) {
-            std::vector<dd::Control> qargs{};
+            std::vector<Control> qargs{};
             for (const auto qubit: qubits) {
-                auto target = qubit.cast<dd::Qubit>();
-                qargs.emplace_back(dd::Control{target});
+                auto target = qubit.cast<Qubit>();
+                qargs.emplace_back(Control{target});
             }
             auto target = qargs.back().qubit;
             qargs.pop_back();
 
-            dd::fp theta = 0., phi = 0., lambda = 0.;
+            fp theta = 0., phi = 0., lambda = 0.;
             if (params.size() == 1) {
-                lambda = params[0].cast<dd::fp>();
+                lambda = params[0].cast<fp>();
             } else if (params.size() == 2) {
-                phi    = params[0].cast<dd::fp>();
-                lambda = params[1].cast<dd::fp>();
+                phi    = params[0].cast<fp>();
+                lambda = params[1].cast<fp>();
             } else if (params.size() == 3) {
-                theta  = params[0].cast<dd::fp>();
-                phi    = params[1].cast<dd::fp>();
-                lambda = params[2].cast<dd::fp>();
+                theta  = params[0].cast<fp>();
+                phi    = params[1].cast<fp>();
+                lambda = params[2].cast<fp>();
             }
-            dd::Controls controls(qargs.cbegin(), qargs.cend());
+            const Controls controls(qargs.cbegin(), qargs.cend());
             qc.emplace_back<StandardOperation>(qc.getNqubits(), controls, target, type, lambda, phi, theta);
         }
 
         static void addTwoTargetOperation(QuantumComputation& qc, OpType type, const py::list& qubits, const py::list& params) {
-            std::vector<dd::Control> qargs{};
+            std::vector<Control> qargs{};
             for (const auto qubit: qubits) {
-                auto target = qubit.cast<dd::Qubit>();
-                qargs.emplace_back(dd::Control{target});
+                auto target = qubit.cast<Qubit>();
+                qargs.emplace_back(Control{target});
             }
             auto target1 = qargs.back().qubit;
             qargs.pop_back();
             auto target0 = qargs.back().qubit;
             qargs.pop_back();
-            dd::fp theta = 0., phi = 0., lambda = 0.;
+            fp theta = 0., phi = 0., lambda = 0.;
             if (params.size() == 1) {
-                lambda = params[0].cast<dd::fp>();
+                lambda = params[0].cast<fp>();
             } else if (params.size() == 2) {
-                phi    = params[0].cast<dd::fp>();
-                lambda = params[1].cast<dd::fp>();
+                phi    = params[0].cast<fp>();
+                lambda = params[1].cast<fp>();
             } else if (params.size() == 3) {
-                theta  = params[0].cast<dd::fp>();
-                phi    = params[1].cast<dd::fp>();
-                lambda = params[2].cast<dd::fp>();
+                theta  = params[0].cast<fp>();
+                phi    = params[1].cast<fp>();
+                lambda = params[2].cast<fp>();
             }
-            dd::Controls controls(qargs.cbegin(), qargs.cend());
+            const Controls controls(qargs.cbegin(), qargs.cend());
             qc.emplace_back<StandardOperation>(qc.getNqubits(), controls, target0, target1, type, lambda, phi, theta);
         }
     };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,18 @@
+# add MQT::DDPackage library
+add_subdirectory("${PROJECT_SOURCE_DIR}/extern/dd_package" "extern/dd_package")
+
+# add MQT::zx library
+add_subdirectory("${PROJECT_SOURCE_DIR}/extern/zx" "extern/zx")
+
+# add nlohmann::json library
+set(JSON_BuildTests # cmake-lint: disable=C0103
+    OFF
+    CACHE INTERNAL "")
+set(JSON_MultipleHeaders # cmake-lint: disable=C0103
+    OFF
+    CACHE INTERNAL "")
+add_subdirectory("${PROJECT_SOURCE_DIR}/extern/json" "extern/json" EXCLUDE_FROM_ALL)
+
 # main project library
 add_library(
   ${PROJECT_NAME}
@@ -44,10 +59,10 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/QCParser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/RealParser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/TFCParser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/parsers/qasm_parser/Parser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/parsers/qasm_parser/Scanner.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/QuantumComputation.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/zx/FunctionalityConstruction.cpp
-  parsers/qasm_parser/Parser.cpp
-  parsers/qasm_parser/Scanner.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/zx/FunctionalityConstruction.cpp)
 
 # set include directories
 target_include_directories(${PROJECT_NAME}
@@ -57,21 +72,8 @@ target_include_directories(${PROJECT_NAME}
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
-# add MQT::DDpackage library
-add_subdirectory("${PROJECT_SOURCE_DIR}/extern/dd_package" "extern/dd_package")
 target_link_libraries(${PROJECT_NAME} PUBLIC MQT::DDPackage)
-
-add_subdirectory("${PROJECT_SOURCE_DIR}/extern/zx" "extern/zx")
 target_link_libraries(${PROJECT_NAME} PUBLIC MQT::zx)
-
-# add nlohmann::json library
-set(JSON_BuildTests # cmake-lint: disable=C0103
-    OFF
-    CACHE INTERNAL "")
-set(JSON_MultipleHeaders # cmake-lint: disable=C0103
-    OFF
-    CACHE INTERNAL "")
-add_subdirectory("${PROJECT_SOURCE_DIR}/extern/json" "extern/json" EXCLUDE_FROM_ALL)
 target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
 
 # enable interprocedural optimization if it is supported

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/ClassicControlledOperation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/CompoundOperation.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/Control.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/NonUnitaryOperation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/Operation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/StandardOperation.hpp
@@ -23,6 +24,7 @@ add_library(
   ${${PROJECT_NAME}_SOURCE_DIR}/include/parsers/qasm_parser/Parser.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/parsers/qasm_parser/Scanner.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/parsers/qasm_parser/Token.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Permutation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/QuantumComputation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/zx/FunctionalityConstruction.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/BernsteinVazirani.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,10 +24,6 @@ add_library(
   ${${PROJECT_NAME}_SOURCE_DIR}/include/algorithms/QPE.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/algorithms/RandomCliffordCircuit.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/CircuitOptimizer.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/dd/FunctionalityConstruction.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/dd/NoiseFunctionality.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Operations.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/dd/Simulation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/ClassicControlledOperation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/operations/CompoundOperation.hpp
@@ -41,7 +37,6 @@ add_library(
   ${${PROJECT_NAME}_SOURCE_DIR}/include/parsers/qasm_parser/Token.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/Permutation.hpp
   ${${PROJECT_NAME}_SOURCE_DIR}/include/QuantumComputation.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/zx/FunctionalityConstruction.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/BernsteinVazirani.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/Entanglement.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/GoogleRandomCircuitSampling.cpp
@@ -61,8 +56,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/TFCParser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/qasm_parser/Parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/parsers/qasm_parser/Scanner.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/QuantumComputation.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/zx/FunctionalityConstruction.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/QuantumComputation.cpp)
 
 # set include directories
 target_include_directories(${PROJECT_NAME}
@@ -72,9 +66,12 @@ target_include_directories(${PROJECT_NAME}
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC MQT::DDPackage)
-target_link_libraries(${PROJECT_NAME} PUBLIC MQT::zx)
 target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
+
+# Temporary: The ZX package is not yet clearly separated and some of its definitions are used
+# throughout the library. Therefore, the ZX package always needs to be linked into the main QFR
+# library.
+target_link_libraries(${PROJECT_NAME} PUBLIC MQT::zx)
 
 # enable interprocedural optimization if it is supported
 enable_lto(${PROJECT_NAME})
@@ -115,3 +112,21 @@ endif()
 
 # add MQT alias
 add_library(MQT::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# add DD Package library
+add_library(
+  ${PROJECT_NAME}_dd INTERFACE ${PROJECT_SOURCE_DIR}/include/dd/FunctionalityConstruction.hpp
+  ${PROJECT_SOURCE_DIR}/include/dd/NoiseFunctionality.hpp
+  ${PROJECT_SOURCE_DIR}/include/dd/Operations.hpp ${PROJECT_SOURCE_DIR}/include/dd/Simulation.hpp)
+target_link_libraries(${PROJECT_NAME}_dd INTERFACE MQT::DDPackage MQT::${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME}_dd
+                           INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/dd>)
+add_library(MQT::${PROJECT_NAME}_dd ALIAS ${PROJECT_NAME}_dd)
+
+# add ZX package library
+add_library(${PROJECT_NAME}_zx ${PROJECT_SOURCE_DIR}/include/zx/FunctionalityConstruction.hpp
+                               ${CMAKE_CURRENT_SOURCE_DIR}/zx/FunctionalityConstruction.cpp)
+target_link_libraries(${PROJECT_NAME}_zx PUBLIC MQT::zx MQT::${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME}_zx
+                           PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/zx>)
+add_library(MQT::${PROJECT_NAME}_zx ALIAS ${PROJECT_NAME}_zx)

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -18,7 +18,7 @@ namespace qc {
                 auto* compOp = dynamic_cast<qc::CompoundOperation*>((*it).get());
                 auto  cit    = compOp->cbegin();
                 while (cit != compOp->cend()) {
-                    const auto cop = cit->get();
+                    const auto* cop = cit->get();
                     if (cop->getType() == qc::I || cop->getType() == Barrier) {
                         cit = compOp->erase(cit);
                     } else {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -5,6 +5,8 @@
 
 #include "CircuitOptimizer.hpp"
 
+#include <cassert>
+
 namespace qc {
     void CircuitOptimizer::removeIdentities(QuantumComputation& qc) {
         // delete the identities from circuit

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -703,12 +703,8 @@ namespace qc {
         for (auto physicalQubitIt = layoutCopy.rbegin(); physicalQubitIt != layoutCopy.rend(); ++physicalQubitIt) {
             auto physicalQubitIndex = physicalQubitIt->first;
             if (isIdleQubit(physicalQubitIndex)) {
-                auto it = outputPermutation.find(physicalQubitIndex);
-                if (it != outputPermutation.end()) {
-                    auto outputIndex = it->second;
-                    if (!force && outputIndex >= 0) {
-                        continue;
-                    }
+                if (auto it = outputPermutation.find(physicalQubitIndex); it != outputPermutation.end() && !force) {
+                    continue;
                 }
 
                 auto logicalQubitIndex = initialLayout.at(physicalQubitIndex);

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -5,6 +5,8 @@
 
 #include "QuantumComputation.hpp"
 
+#include <cassert>
+
 namespace qc {
 
     /***

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -61,28 +61,28 @@ namespace qc {
     }
 
     void QuantumComputation::import(const std::string& filename) {
-        size_t      dot       = filename.find_last_of('.');
-        std::string extension = filename.substr(dot + 1);
+        const std::size_t dot       = filename.find_last_of('.');
+        std::string       extension = filename.substr(dot + 1);
         std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char ch) { return ::tolower(ch); });
         if (extension == "real") {
-            import(filename, Real);
+            import(filename, Format::Real);
         } else if (extension == "qasm") {
-            import(filename, OpenQASM);
+            import(filename, Format::OpenQASM);
         } else if (extension == "txt") {
-            import(filename, GRCS);
+            import(filename, Format::GRCS);
         } else if (extension == "tfc") {
-            import(filename, TFC);
+            import(filename, Format::TFC);
         } else if (extension == "qc") {
-            import(filename, QC);
+            import(filename, Format::QC);
         } else {
             throw QFRException("[import] extension " + extension + " not recognized");
         }
     }
 
     void QuantumComputation::import(const std::string& filename, Format format) {
-        size_t slash = filename.find_last_of('/');
-        size_t dot   = filename.find_last_of('.');
-        name         = filename.substr(slash + 1, dot - slash - 1);
+        const std::size_t slash = filename.find_last_of('/');
+        const std::size_t dot   = filename.find_last_of('.');
+        name                    = filename.substr(slash + 1, dot - slash - 1);
 
         auto ifs = std::ifstream(filename);
         if (ifs.good()) {
@@ -97,24 +97,24 @@ namespace qc {
         reset();
 
         switch (format) {
-            case Real:
+            case Format::Real:
                 importReal(is);
                 break;
-            case OpenQASM:
+            case Format::OpenQASM:
                 updateMaxControls(2);
                 importOpenQASM(is);
                 break;
-            case GRCS:
+            case Format::GRCS:
                 importGRCS(is);
                 break;
-            case TFC:
+            case Format::TFC:
                 importTFC(is);
                 break;
-            case QC:
+            case Format::QC:
                 importQC(is);
                 break;
             default:
-                throw QFRException("[import] Format " + std::to_string(format) + " not yet supported");
+                throw QFRException("[import] format not recognized");
         }
 
         // initialize the initial layout and output permutation
@@ -124,24 +124,25 @@ namespace qc {
     void QuantumComputation::initializeIOMapping() {
         // if no initial layout was found during parsing the identity mapping is assumed
         if (initialLayout.empty()) {
-            for (dd::QubitCount i = 0; i < nqubits; ++i)
-                initialLayout.insert({static_cast<dd::Qubit>(i), static_cast<dd::Qubit>(i)});
+            for (Qubit i = 0; i < nqubits; ++i) {
+                initialLayout.emplace(i, i);
+            }
         }
 
         // try gathering (additional) output permutation information from measurements, e.g., a measurement
         //      `measure q[i] -> c[j];`
         // implies that the j-th (logical) output is obtained from measuring the i-th physical qubit.
-        bool outputPermutationFound = !outputPermutation.empty();
+        const bool outputPermutationFound = !outputPermutation.empty();
 
         // track whether the circuit contains measurements at the end of the circuit
         // if it does, then all qubits that are not measured shall be considered garbage outputs
-        bool                outputPermutationFromMeasurements = false;
-        std::set<dd::Qubit> measuredQubits{};
+        bool            outputPermutationFromMeasurements = false;
+        std::set<Qubit> measuredQubits{};
 
         for (auto opIt = ops.begin(); opIt != ops.end(); ++opIt) {
             if ((*opIt)->getType() == qc::Measure) {
                 outputPermutationFromMeasurements = true;
-                auto op                           = dynamic_cast<NonUnitaryOperation*>(opIt->get());
+                auto* op                          = dynamic_cast<NonUnitaryOperation*>(opIt->get());
                 assert(op->getTargets().size() == op->getClassics().size());
                 auto classicIt = op->getClassics().cbegin();
                 for (const auto& q: op->getTargets()) {
@@ -162,11 +163,11 @@ namespace qc {
                                     break;
                                 }
                             }
-                            outputPermutation.at(qubitidx) = static_cast<dd::Qubit>(bitidx);
+                            outputPermutation.at(qubitidx) = static_cast<Qubit>(bitidx);
                         }
                     } else {
                         // directly set permutation if none was set beforehand
-                        outputPermutation[qubitidx] = static_cast<dd::Qubit>(bitidx);
+                        outputPermutation[qubitidx] = static_cast<Qubit>(bitidx);
                     }
                     measuredQubits.emplace(qubitidx);
                     ++classicIt;
@@ -189,10 +190,10 @@ namespace qc {
 
         // if the output permutation is still empty, we assume the identity (i.e., it is equal to the initial layout)
         if (outputPermutation.empty()) {
-            for (dd::QubitCount i = 0; i < nqubits; ++i) {
+            for (Qubit i = 0; i < nqubits; ++i) {
                 // only add to output permutation if the qubit is actually acted upon
-                if (!isIdleQubit(static_cast<dd::Qubit>(i))) {
-                    outputPermutation.insert({static_cast<dd::Qubit>(i), initialLayout.at(static_cast<dd::Qubit>(i))});
+                if (!isIdleQubit(i)) {
+                    outputPermutation.insert({i, initialLayout.at(i)});
                 }
             }
         }
@@ -212,32 +213,25 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::addQubitRegister(std::size_t nq, const char* reg_name) {
-        if (static_cast<std::size_t>(nqubits + nancillae + nq) > dd::Package<>::MAX_POSSIBLE_QUBITS) {
-            throw QFRException("Requested too many qubits to be handled by the DD package. Qubit datatype only allows up to " +
-                               std::to_string(dd::Package<>::MAX_POSSIBLE_QUBITS) + " qubits, while " +
-                               std::to_string(nqubits + nancillae + nq) + " were requested. If you want to use more than " +
-                               std::to_string(dd::Package<>::MAX_POSSIBLE_QUBITS) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
-        }
-
-        if (qregs.count(reg_name)) {
-            auto& reg = qregs.at(reg_name);
+    void QuantumComputation::addQubitRegister(std::size_t nq, const char* regName) {
+        if (qregs.count(regName) != 0) {
+            auto& reg = qregs.at(regName);
             if (reg.first + reg.second == nqubits + nancillae) {
                 reg.second += nq;
             } else {
                 throw QFRException("[addQubitRegister] Augmenting existing qubit registers is only supported for the last register in a circuit");
             }
         } else {
-            qregs.insert({reg_name, {nqubits, static_cast<dd::QubitCount>(nq)}});
+            qregs.try_emplace(regName, nqubits, nq);
         }
         assert(nancillae == 0); // should only reach this point if no ancillae are present
 
         for (std::size_t i = 0; i < nq; ++i) {
-            auto j = static_cast<dd::Qubit>(nqubits + i);
+            auto j = nqubits + i;
             initialLayout.insert({j, j});
             outputPermutation.insert({j, j});
         }
-        nqubits += static_cast<dd::QubitCount>(nq);
+        nqubits += nq;
 
         for (auto& op: ops) {
             op->setNqubits(nqubits + nancillae);
@@ -247,44 +241,37 @@ namespace qc {
         garbage.resize(nqubits + nancillae);
     }
 
-    void QuantumComputation::addClassicalRegister(std::size_t nc, const char* reg_name) {
-        if (cregs.count(reg_name)) {
+    void QuantumComputation::addClassicalRegister(std::size_t nc, const char* regName) {
+        if (cregs.count(regName) != 0) {
             throw QFRException("[addClassicalRegister] Augmenting existing classical registers is currently not supported");
         }
 
-        cregs.insert({reg_name, {nclassics, nc}});
+        cregs.try_emplace(regName, nclassics, nc);
         nclassics += nc;
     }
 
-    void QuantumComputation::addAncillaryRegister(std::size_t nq, const char* reg_name) {
-        if (static_cast<std::size_t>(nqubits + nancillae + nq) > dd::Package<>::MAX_POSSIBLE_QUBITS) {
-            throw QFRException("Requested too many qubits to be handled by the DD package. Qubit datatype only allows up to " +
-                               std::to_string(dd::Package<>::MAX_POSSIBLE_QUBITS) + " qubits, while " +
-                               std::to_string(nqubits + nancillae + nq) + " were requested. If you want to use more than " +
-                               std::to_string(dd::Package<>::MAX_POSSIBLE_QUBITS) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
-        }
-
-        dd::QubitCount totalqubits = nqubits + nancillae;
-        if (ancregs.count(reg_name)) {
-            auto& reg = ancregs.at(reg_name);
+    void QuantumComputation::addAncillaryRegister(std::size_t nq, const char* regName) {
+        const auto totalqubits = nqubits + nancillae;
+        if (ancregs.count(regName) != 0) {
+            auto& reg = ancregs.at(regName);
             if (reg.first + reg.second == totalqubits) {
                 reg.second += nq;
             } else {
                 throw QFRException("[addAncillaryRegister] Augmenting existing ancillary registers is only supported for the last register in a circuit");
             }
         } else {
-            ancregs.insert({reg_name, {totalqubits, static_cast<dd::QubitCount>(nq)}});
+            ancregs.try_emplace(regName, totalqubits, nq);
         }
 
         ancillary.resize(totalqubits + nq);
         garbage.resize(totalqubits + nq);
         for (std::size_t i = 0; i < nq; ++i) {
-            auto j = static_cast<dd::Qubit>(totalqubits + i);
+            auto j = static_cast<Qubit>(totalqubits + i);
             initialLayout.insert({j, j});
             outputPermutation.insert({j, j});
             ancillary[j] = true;
         }
-        nancillae += static_cast<dd::QubitCount>(nq);
+        nancillae += nq;
 
         for (auto& op: ops) {
             op->setNqubits(nqubits + nancillae);
@@ -293,18 +280,19 @@ namespace qc {
 
     // removes the i-th logical qubit and returns the index j it was assigned to in the initial layout
     // i.e., initialLayout[j] = i
-    std::pair<dd::Qubit, dd::Qubit> QuantumComputation::removeQubit(dd::Qubit logical_qubit_index) {
+    std::pair<Qubit, std::optional<Qubit>> QuantumComputation::removeQubit(const Qubit logicalQubitIndex) {
         // Find index of the physical qubit i is assigned to
-        dd::Qubit physical_qubit_index = 0;
+        Qubit physicalQubitIndex = 0;
         for (const auto& Q: initialLayout) {
-            if (Q.second == logical_qubit_index)
-                physical_qubit_index = Q.first;
+            if (Q.second == logicalQubitIndex) {
+                physicalQubitIndex = Q.first;
+            }
         }
 
         // get register and register-index of the corresponding qubit
-        auto reg = getQubitRegisterAndIndex(physical_qubit_index);
+        auto reg = getQubitRegisterAndIndex(physicalQubitIndex);
 
-        if (physicalQubitIsAncillary(physical_qubit_index)) {
+        if (physicalQubitIsAncillary(physicalQubitIndex)) {
             // first index
             if (reg.second == 0) {
                 // last remaining qubit of register
@@ -322,17 +310,17 @@ namespace qc {
                 // reduce count of register
                 ancregs[reg.first].second--;
             } else {
-                auto ancreg     = ancregs.at(reg.first);
-                auto low_part   = reg.first + "_l";
-                auto low_index  = ancreg.first;
-                auto low_count  = reg.second;
-                auto high_part  = reg.first + "_h";
-                auto high_index = ancreg.first + reg.second + 1;
-                auto high_count = ancreg.second - reg.second - 1;
+                auto ancreg    = ancregs.at(reg.first);
+                auto lowPart   = reg.first + "_l";
+                auto lowIndex  = ancreg.first;
+                auto lowCount  = reg.second;
+                auto highPart  = reg.first + "_h";
+                auto highIndex = ancreg.first + reg.second + 1;
+                auto highCount = ancreg.second - reg.second - 1;
 
                 ancregs.erase(reg.first);
-                ancregs.insert({low_part, {low_index, low_count}});
-                ancregs.insert({high_part, {high_index, high_count}});
+                ancregs.try_emplace(lowPart, lowIndex, lowCount);
+                ancregs.try_emplace(highPart, highIndex, highCount);
             }
             // reduce ancilla count
             nancillae--;
@@ -353,42 +341,41 @@ namespace qc {
                 // reduce count of register
                 qregs[reg.first].second--;
             } else {
-                auto qreg       = qregs.at(reg.first);
-                auto low_part   = reg.first + "_l";
-                auto low_index  = qreg.first;
-                auto low_count  = reg.second;
-                auto high_part  = reg.first + "_h";
-                auto high_index = qreg.first + reg.second + 1;
-                auto high_count = qreg.second - reg.second - 1;
+                auto qreg      = qregs.at(reg.first);
+                auto lowPart   = reg.first + "_l";
+                auto lowIndex  = qreg.first;
+                auto lowCount  = reg.second;
+                auto highPart  = reg.first + "_h";
+                auto highIndex = qreg.first + reg.second + 1;
+                auto highCount = qreg.second - reg.second - 1;
 
                 qregs.erase(reg.first);
-                qregs.insert({low_part, {low_index, low_count}});
-                qregs.insert({high_part, {high_index, high_count}});
+                qregs.try_emplace(lowPart, lowIndex, lowCount);
+                qregs.try_emplace(highPart, highIndex, highCount);
             }
             // reduce qubit count
             nqubits--;
         }
 
         // adjust initial layout permutation
-        initialLayout.erase(physical_qubit_index);
+        initialLayout.erase(physicalQubitIndex);
 
         // remove potential output permutation entry
-        dd::Qubit output_qubit_index = -1;
-        auto      it                 = outputPermutation.find(physical_qubit_index);
-        if (it != outputPermutation.end()) {
-            output_qubit_index = it->second;
+        std::optional<Qubit> outputQubitIndex{};
+        if (const auto it = outputPermutation.find(physicalQubitIndex); it != outputPermutation.end()) {
+            outputQubitIndex = it->second;
             // erasing entry
-            outputPermutation.erase(physical_qubit_index);
+            outputPermutation.erase(physicalQubitIndex);
         }
 
         // update all operations
-        auto totalQubits = static_cast<dd::QubitCount>(nqubits + nancillae);
+        const auto totalQubits = nqubits + nancillae;
         for (auto& op: ops) {
             op->setNqubits(totalQubits);
         }
 
         // update ancillary and garbage tracking
-        for (dd::QubitCount i = logical_qubit_index; i < totalQubits; ++i) {
+        for (std::size_t i = logicalQubitIndex; i < totalQubits; ++i) {
             ancillary[i] = ancillary[i + 1];
             garbage[i]   = garbage[i + 1];
         }
@@ -396,61 +383,61 @@ namespace qc {
         ancillary[totalQubits] = false;
         garbage[totalQubits]   = false;
 
-        return {physical_qubit_index, output_qubit_index};
+        return {physicalQubitIndex, outputQubitIndex};
     }
 
     // adds j-th physical qubit as ancilla to the end of reg or creates the register if necessary
-    void QuantumComputation::addAncillaryQubit(dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index) {
-        if (initialLayout.count(physical_qubit_index) || outputPermutation.count(physical_qubit_index)) {
+    void QuantumComputation::addAncillaryQubit(Qubit physicalQubitIndex, std::optional<Qubit> outputQubitIndex) {
+        if (initialLayout.count(physicalQubitIndex) || outputPermutation.count(physicalQubitIndex)) {
             throw QFRException("[addAncillaryQubit] Attempting to insert physical qubit that is already assigned");
         }
 
         bool fusionPossible = false;
         for (auto& ancreg: ancregs) {
-            auto& anc_start_index = ancreg.second.first;
-            auto& anc_count       = ancreg.second.second;
+            auto& ancStartIndex = ancreg.second.first;
+            auto& ancCount      = ancreg.second.second;
             // 1st case: can append to start of existing register
-            if (anc_start_index == physical_qubit_index + 1) {
-                anc_start_index--;
-                anc_count++;
+            if (ancStartIndex == physicalQubitIndex + 1) {
+                ancStartIndex--;
+                ancCount++;
                 fusionPossible = true;
                 break;
             }
             // 2nd case: can append to end of existing register
-            else if (anc_start_index + anc_count == physical_qubit_index) {
-                anc_count++;
+            if (ancStartIndex + ancCount == physicalQubitIndex) {
+                ancCount++;
                 fusionPossible = true;
                 break;
             }
         }
 
         if (ancregs.empty()) {
-            ancregs.insert({DEFAULT_ANCREG, {physical_qubit_index, 1}});
+            ancregs.try_emplace(DEFAULT_ANCREG, physicalQubitIndex, 1);
         } else if (!fusionPossible) {
-            auto new_reg_name = std::string(DEFAULT_ANCREG) + "_" + std::to_string(physical_qubit_index);
-            ancregs.insert({new_reg_name, {physical_qubit_index, 1}});
+            auto newRegName = std::string(DEFAULT_ANCREG) + "_" + std::to_string(physicalQubitIndex);
+            ancregs.try_emplace(newRegName, physicalQubitIndex, 1);
         }
 
         // index of logical qubit
-        auto logical_qubit_index = static_cast<dd::Qubit>(nqubits + nancillae);
+        auto logicalQubitIndex = nqubits + nancillae;
 
         // resize ancillary and garbage tracking vectors
-        ancillary.resize(logical_qubit_index + 1U);
-        garbage.resize(logical_qubit_index + 1U);
+        ancillary.resize(logicalQubitIndex + 1U);
+        garbage.resize(logicalQubitIndex + 1U);
 
         // increase ancillae count and mark as ancillary
         nancillae++;
-        ancillary[logical_qubit_index] = true;
+        ancillary[logicalQubitIndex] = true;
 
         // adjust initial layout
-        initialLayout.insert({physical_qubit_index, logical_qubit_index});
+        initialLayout.insert({physicalQubitIndex, logicalQubitIndex});
 
         // adjust output permutation
-        if (output_qubit_index >= 0) {
-            outputPermutation.insert({physical_qubit_index, output_qubit_index});
+        if (outputQubitIndex.has_value()) {
+            outputPermutation.insert({physicalQubitIndex, *outputQubitIndex});
         } else {
             // if a qubit is not relevant for the output, it is considered garbage
-            garbage[logical_qubit_index] = true;
+            garbage[logicalQubitIndex] = true;
         }
 
         // update all operations
@@ -459,14 +446,14 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::addQubit(dd::Qubit logical_qubit_index, dd::Qubit physical_qubit_index, dd::Qubit output_qubit_index) {
-        if (initialLayout.count(physical_qubit_index) || outputPermutation.count(physical_qubit_index)) {
+    void QuantumComputation::addQubit(const Qubit logicalQubitIndex, const Qubit physicalQubitIndex, const std::optional<Qubit> outputQubitIndex) {
+        if (initialLayout.count(physicalQubitIndex) || outputPermutation.count(physicalQubitIndex)) {
             throw QFRException("[addQubit] Attempting to insert physical qubit that is already assigned");
         }
 
-        if (logical_qubit_index > nqubits) {
+        if (logicalQubitIndex > nqubits) {
             throw QFRException("[addQubit] There are currently only " + std::to_string(nqubits) +
-                               " qubits in the circuit. Adding " + std::to_string(logical_qubit_index) +
+                               " qubits in the circuit. Adding " + std::to_string(logicalQubitIndex) +
                                " is therefore not possible at the moment.");
             // TODO: this does not necessarily have to lead to an error. A new qubit register could be created and all ancillaries shifted
         }
@@ -474,24 +461,24 @@ namespace qc {
         // check if qubit fits in existing register
         bool fusionPossible = false;
         for (auto& qreg: qregs) {
-            auto& q_start_index = qreg.second.first;
-            auto& q_count       = qreg.second.second;
+            auto& qStartIndex = qreg.second.first;
+            auto& qCount      = qreg.second.second;
             // 1st case: can append to start of existing register
-            if (q_start_index == physical_qubit_index + 1) {
-                q_start_index--;
-                q_count++;
+            if (qStartIndex == physicalQubitIndex + 1) {
+                qStartIndex--;
+                qCount++;
                 fusionPossible = true;
                 break;
             }
             // 2nd case: can append to end of existing register
-            else if (q_start_index + q_count == physical_qubit_index) {
-                if (physical_qubit_index == nqubits) {
+            if (qStartIndex + qCount == physicalQubitIndex) {
+                if (physicalQubitIndex == nqubits) {
                     // need to shift ancillaries
                     for (auto& ancreg: ancregs) {
                         ancreg.second.first++;
                     }
                 }
-                q_count++;
+                qCount++;
                 fusionPossible = true;
                 break;
             }
@@ -500,19 +487,19 @@ namespace qc {
         consolidateRegister(qregs);
 
         if (qregs.empty()) {
-            qregs.insert({DEFAULT_QREG, {physical_qubit_index, 1}});
+            qregs.try_emplace(DEFAULT_QREG, physicalQubitIndex, 1);
         } else if (!fusionPossible) {
-            auto new_reg_name = std::string(DEFAULT_QREG) + "_" + std::to_string(physical_qubit_index);
-            qregs.insert({new_reg_name, {physical_qubit_index, 1}});
+            auto newRegName = std::string(DEFAULT_QREG) + "_" + std::to_string(physicalQubitIndex);
+            qregs.try_emplace(newRegName, physicalQubitIndex, 1);
         }
 
         // increase qubit count
         nqubits++;
         // adjust initial layout
-        initialLayout.insert({physical_qubit_index, logical_qubit_index});
-        if (output_qubit_index >= 0) {
+        initialLayout.insert({physicalQubitIndex, logicalQubitIndex});
+        if (outputQubitIndex.has_value()) {
             // adjust output permutation
-            outputPermutation.insert({physical_qubit_index, output_qubit_index});
+            outputPermutation.insert({physicalQubitIndex, *outputQubitIndex});
         }
         // update all operations
         for (auto& op: ops) {
@@ -520,13 +507,13 @@ namespace qc {
         }
 
         // update ancillary and garbage tracking
-        for (auto i = static_cast<dd::Qubit>(nqubits + nancillae - 1); i > logical_qubit_index; --i) {
+        for (auto i = nqubits + nancillae - 1; i > logicalQubitIndex; --i) {
             ancillary[i] = ancillary[i - 1];
             garbage[i]   = garbage[i - 1];
         }
         // unset new entry
-        ancillary[logical_qubit_index] = false;
-        garbage[logical_qubit_index]   = false;
+        ancillary[logicalQubitIndex] = false;
+        garbage[logicalQubitIndex]   = false;
     }
 
     std::ostream& QuantumComputation::print(std::ostream& os) const {
@@ -538,10 +525,11 @@ namespace qc {
             os << "i: \t\t\t";
         }
         for (const auto& Q: initialLayout) {
-            if (ancillary[Q.second])
+            if (ancillary[Q.second]) {
                 os << "\033[31m" << static_cast<std::size_t>(Q.second) << "\t\033[0m";
-            else
+            } else {
                 os << static_cast<std::size_t>(Q.second) << "\t";
+            }
         }
         os << std::endl;
         size_t i = 0U;
@@ -556,10 +544,10 @@ namespace qc {
         } else {
             os << "o: \t\t\t";
         }
-        for (const auto& physical_qubit: initialLayout) {
-            auto it = outputPermutation.find(physical_qubit.first);
+        for (const auto& physicalQubit: initialLayout) {
+            auto it = outputPermutation.find(physicalQubit.first);
             if (it == outputPermutation.end()) {
-                if (garbage[physical_qubit.second]) {
+                if (garbage[physicalQubit.second]) {
                     os << "\033[31m|\t\033[0m";
                 } else {
                     os << "|\t";
@@ -573,8 +561,9 @@ namespace qc {
     }
 
     void QuantumComputation::printBin(std::size_t n, std::stringstream& ss) {
-        if (n > 1)
+        if (n > 1) {
             printBin(n / 2, ss);
+        }
         ss << n % 2;
     }
 
@@ -592,15 +581,15 @@ namespace qc {
         std::string extension = filename.substr(dot + 1);
         std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char c) { return ::tolower(c); });
         if (extension == "real") {
-            dump(filename, Real);
+            dump(filename, Format::Real);
         } else if (extension == "qasm") {
-            dump(filename, OpenQASM);
+            dump(filename, Format::OpenQASM);
         } else if (extension == "qc") {
-            dump(filename, QC);
+            dump(filename, Format::QC);
         } else if (extension == "tfc") {
-            dump(filename, TFC);
+            dump(filename, Format::TFC);
         } else if (extension == "tensor") {
-            dump(filename, Tensor);
+            dump(filename, Format::Tensor);
         } else {
             throw QFRException("[dump] Extension " + extension + " not recognized/supported for dumping.");
         }
@@ -609,18 +598,19 @@ namespace qc {
     void QuantumComputation::dumpOpenQASM(std::ostream& of) {
         // Add missing physical qubits
         if (!qregs.empty()) {
-            for (dd::QubitCount physical_qubit = 0; physical_qubit < initialLayout.rbegin()->first; ++physical_qubit) {
-                if (!initialLayout.count(static_cast<dd::Qubit>(physical_qubit))) {
-                    auto logicalQubit = static_cast<dd::Qubit>(getHighestLogicalQubitIndex() + 1);
-                    addQubit(logicalQubit, static_cast<dd::Qubit>(physical_qubit), -1);
+            for (Qubit physicalQubit = 0; physicalQubit < initialLayout.rbegin()->first; ++physicalQubit) {
+                if (initialLayout.count(physicalQubit) == 0) {
+                    const auto logicalQubit = getHighestLogicalQubitIndex() + 1;
+                    addQubit(logicalQubit, physicalQubit, std::nullopt);
                 }
             }
         }
 
         // dump initial layout and output permutation
         Permutation inverseInitialLayout{};
-        for (const auto& q: initialLayout)
+        for (const auto& q: initialLayout) {
             inverseInitialLayout.insert({q.second, q.first});
+        }
         of << "// i";
         for (const auto& q: inverseInitialLayout) {
             of << " " << static_cast<std::size_t>(q.second);
@@ -662,28 +652,13 @@ namespace qc {
         createRegisterArray(cregs, cregnames, nclassics, DEFAULT_CREG);
         createRegisterArray(ancregs, ancregnames, nancillae, DEFAULT_ANCREG);
 
-        for (const auto& ancregname: ancregnames)
+        for (const auto& ancregname: ancregnames) {
             qregnames.push_back(ancregname);
+        }
 
         for (const auto& op: ops) {
             op->dumpOpenQASM(of, qregnames, cregnames);
         }
-    }
-
-    void QuantumComputation::dumpTensorNetwork(std::ostream& of) const {
-        of << "{\"tensors\": [\n";
-
-        // initialize an index for every qubit
-        auto        inds    = std::vector<std::size_t>(getNqubits(), 0U);
-        std::size_t gateIdx = 0U;
-        auto        dd      = std::make_unique<dd::Package<>>(getNqubits());
-        for (const auto& op: ops) {
-            const auto type = op->getType();
-            if (op != ops.front() && (type != Measure && type != Barrier && type != ShowProbabilities && type != Snapshot))
-                of << ",\n";
-            dumpTensor(op.get(), of, inds, gateIdx, dd);
-        }
-        of << "\n]}\n";
     }
 
     void QuantumComputation::dump(const std::string& filename, Format format) {
@@ -697,54 +672,57 @@ namespace qc {
 
     void QuantumComputation::dump(std::ostream&& of, Format format) {
         switch (format) {
-            case OpenQASM:
+            case Format::OpenQASM:
                 dumpOpenQASM(of);
                 break;
-            case Tensor:
-                dumpTensorNetwork(of);
-                break;
-            case Real:
+            case Format::Real:
                 std::cerr << "Dumping in real format currently not supported\n";
                 break;
-            case GRCS:
+            case Format::GRCS:
                 std::cerr << "Dumping in GRCS format currently not supported\n";
                 break;
-            case TFC:
+            case Format::TFC:
                 std::cerr << "Dumping in TFC format currently not supported\n";
                 break;
-            case QC:
+            case Format::QC:
                 std::cerr << "Dumping in QC format currently not supported\n";
                 break;
+            default:
+                throw QFRException("[dump] Format not recognized/supported for dumping.");
         }
     }
 
-    bool QuantumComputation::isIdleQubit(dd::Qubit physicalQubit) const {
+    bool QuantumComputation::isIdleQubit(const Qubit physicalQubit) const {
         return !std::any_of(ops.cbegin(), ops.cend(), [&physicalQubit](const auto& op) { return op->actsOn(physicalQubit); });
     }
 
     void QuantumComputation::stripIdleQubits(bool force, bool reduceIOpermutations) {
-        auto layout_copy = initialLayout;
-        for (auto physical_qubit_it = layout_copy.rbegin(); physical_qubit_it != layout_copy.rend(); ++physical_qubit_it) {
-            auto physical_qubit_index = physical_qubit_it->first;
-            if (isIdleQubit(physical_qubit_index)) {
-                auto it = outputPermutation.find(physical_qubit_index);
+        auto layoutCopy = initialLayout;
+        for (auto physicalQubitIt = layoutCopy.rbegin(); physicalQubitIt != layoutCopy.rend(); ++physicalQubitIt) {
+            auto physicalQubitIndex = physicalQubitIt->first;
+            if (isIdleQubit(physicalQubitIndex)) {
+                auto it = outputPermutation.find(physicalQubitIndex);
                 if (it != outputPermutation.end()) {
-                    auto output_index = it->second;
-                    if (!force && output_index >= 0) continue;
+                    auto outputIndex = it->second;
+                    if (!force && outputIndex >= 0) {
+                        continue;
+                    }
                 }
 
-                auto logical_qubit_index = initialLayout.at(physical_qubit_index);
-                removeQubit(logical_qubit_index);
+                auto logicalQubitIndex = initialLayout.at(physicalQubitIndex);
+                removeQubit(logicalQubitIndex);
 
-                if (reduceIOpermutations && (logical_qubit_index < nqubits + nancillae)) {
+                if (reduceIOpermutations && (logicalQubitIndex < nqubits + nancillae)) {
                     for (auto& q: initialLayout) {
-                        if (q.second > logical_qubit_index)
+                        if (q.second > logicalQubitIndex) {
                             q.second--;
+                        }
                     }
 
                     for (auto& q: outputPermutation) {
-                        if (q.second > logical_qubit_index)
+                        if (q.second > logicalQubitIndex) {
                             q.second--;
+                        }
                     }
                 }
             }
@@ -754,75 +732,87 @@ namespace qc {
         }
     }
 
-    std::string QuantumComputation::getQubitRegister(dd::Qubit physicalQubitIndex) const {
+    std::string QuantumComputation::getQubitRegister(const Qubit physicalQubitIndex) const {
         for (const auto& reg: qregs) {
-            auto start_idx = reg.second.first;
-            auto count     = reg.second.second;
-            if (physicalQubitIndex < start_idx) continue;
-            if (physicalQubitIndex >= start_idx + count) continue;
+            auto startIdx = reg.second.first;
+            auto count    = reg.second.second;
+            if (physicalQubitIndex < startIdx) {
+                continue;
+            }
+            if (physicalQubitIndex >= startIdx + count) {
+                continue;
+            }
             return reg.first;
         }
         for (const auto& reg: ancregs) {
-            auto start_idx = reg.second.first;
-            auto count     = reg.second.second;
-            if (physicalQubitIndex < start_idx) continue;
-            if (physicalQubitIndex >= start_idx + count) continue;
+            auto startIdx = reg.second.first;
+            auto count    = reg.second.second;
+            if (physicalQubitIndex < startIdx) {
+                continue;
+            }
+            if (physicalQubitIndex >= startIdx + count) {
+                continue;
+            }
             return reg.first;
         }
 
         throw QFRException("[getQubitRegister] Qubit index " + std::to_string(physicalQubitIndex) + " not found in any register");
     }
 
-    std::pair<std::string, dd::Qubit> QuantumComputation::getQubitRegisterAndIndex(dd::Qubit physicalQubitIndex) const {
-        std::string reg_name = getQubitRegister(physicalQubitIndex);
-        dd::Qubit   index    = 0;
-        auto        it       = qregs.find(reg_name);
+    std::pair<std::string, Qubit> QuantumComputation::getQubitRegisterAndIndex(const Qubit physicalQubitIndex) const {
+        std::string regName = getQubitRegister(physicalQubitIndex);
+        Qubit       index   = 0;
+        auto        it      = qregs.find(regName);
         if (it != qregs.end()) {
-            index = static_cast<dd::Qubit>(physicalQubitIndex - it->second.first);
+            index = static_cast<Qubit>(physicalQubitIndex - it->second.first);
         } else {
-            auto it_anc = ancregs.find(reg_name);
+            auto it_anc = ancregs.find(regName);
             if (it_anc != ancregs.end()) {
-                index = static_cast<dd::Qubit>(physicalQubitIndex - it_anc->second.first);
+                index = static_cast<Qubit>(physicalQubitIndex - it_anc->second.first);
             }
             // no else branch needed here, since error would have already shown in getQubitRegister(physicalQubitIndex)
         }
-        return {reg_name, index};
+        return {regName, index};
     }
 
-    std::string QuantumComputation::getClassicalRegister(std::size_t classicalIndex) const {
+    std::string QuantumComputation::getClassicalRegister(const Bit classicalIndex) const {
         for (const auto& reg: cregs) {
-            auto start_idx = reg.second.first;
-            auto count     = reg.second.second;
-            if (classicalIndex < start_idx) continue;
-            if (classicalIndex >= start_idx + count) continue;
+            auto startIdx = reg.second.first;
+            auto count    = reg.second.second;
+            if (classicalIndex < startIdx) {
+                continue;
+            }
+            if (classicalIndex >= startIdx + count) {
+                continue;
+            }
             return reg.first;
         }
 
         throw QFRException("[getClassicalRegister] Classical index " + std::to_string(classicalIndex) + " not found in any register");
     }
 
-    std::pair<std::string, std::size_t> QuantumComputation::getClassicalRegisterAndIndex(std::size_t classicalIndex) const {
-        std::string reg_name = getClassicalRegister(classicalIndex);
-        std::size_t index    = 0;
-        auto        it       = cregs.find(reg_name);
+    std::pair<std::string, Bit> QuantumComputation::getClassicalRegisterAndIndex(const Bit classicalIndex) const {
+        std::string regName = getClassicalRegister(classicalIndex);
+        std::size_t index   = 0;
+        auto        it      = cregs.find(regName);
         if (it != cregs.end()) {
             index = classicalIndex - it->second.first;
         } // else branch not needed since getClassicalRegister already covers this case
-        return {reg_name, index};
+        return {regName, index};
     }
 
-    dd::Qubit QuantumComputation::getIndexFromQubitRegister(const std::pair<std::string, dd::Qubit>& qubit) const {
+    Qubit QuantumComputation::getIndexFromQubitRegister(const std::pair<std::string, Qubit>& qubit) const {
         // no range check is performed here!
-        return static_cast<dd::Qubit>(qregs.at(qubit.first).first + qubit.second);
+        return qregs.at(qubit.first).first + qubit.second;
     }
-    std::size_t QuantumComputation::getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const {
+    Bit QuantumComputation::getIndexFromClassicalRegister(const std::pair<std::string, std::size_t>& clbit) const {
         // no range check is performed here!
-        return static_cast<std::size_t>(cregs.at(clbit.first).first + clbit.second);
+        return cregs.at(clbit.first).first + clbit.second;
     }
 
     std::ostream& QuantumComputation::printPermutation(const Permutation& permutation, std::ostream& os) {
-        for (const auto& Q: permutation) {
-            os << "\t" << static_cast<std::size_t>(Q.first) << ": " << static_cast<std::size_t>(Q.second) << std::endl;
+        for (const auto& [physical, logical]: permutation) {
+            os << "\t" << physical << ": " << logical << std::endl;
         }
         return os;
     }
@@ -830,13 +820,13 @@ namespace qc {
     std::ostream& QuantumComputation::printRegisters(std::ostream& os) const {
         os << "qregs:";
         for (const auto& qreg: qregs) {
-            os << " {" << qreg.first << ", {" << static_cast<std::size_t>(qreg.second.first) << ", " << static_cast<std::size_t>(qreg.second.second) << "}}";
+            os << " {" << qreg.first << ", {" << qreg.second.first << ", " << qreg.second.second << "}}";
         }
         os << std::endl;
         if (!ancregs.empty()) {
             os << "ancregs:";
             for (const auto& ancreg: ancregs) {
-                os << " {" << ancreg.first << ", {" << static_cast<std::size_t>(ancreg.second.first) << ", " << static_cast<std::size_t>(ancreg.second.second) << "}}";
+                os << " {" << ancreg.first << ", {" << ancreg.second.first << ", " << ancreg.second.second << "}}";
             }
             os << std::endl;
         }
@@ -848,19 +838,19 @@ namespace qc {
         return os;
     }
 
-    dd::Qubit QuantumComputation::getHighestLogicalQubitIndex(const Permutation& permutation) {
-        dd::Qubit max_index = 0;
-        for (const auto& physical_qubit: permutation) {
-            max_index = std::max(max_index, physical_qubit.second);
+    Qubit QuantumComputation::getHighestLogicalQubitIndex(const Permutation& permutation) {
+        Qubit maxIndex = 0;
+        for (const auto& [physical, logical]: permutation) {
+            maxIndex = std::max(maxIndex, logical);
         }
-        return max_index;
+        return maxIndex;
     }
 
-    bool QuantumComputation::physicalQubitIsAncillary(dd::Qubit physicalQubitIndex) const {
+    bool QuantumComputation::physicalQubitIsAncillary(const Qubit physicalQubitIndex) const {
         return std::any_of(ancregs.cbegin(), ancregs.cend(), [&physicalQubitIndex](const auto& ancreg) { return ancreg.second.first <= physicalQubitIndex && physicalQubitIndex < ancreg.second.first + ancreg.second.second; });
     }
 
-    void QuantumComputation::setLogicalQubitGarbage(dd::Qubit logicalQubitIndex) {
+    void QuantumComputation::setLogicalQubitGarbage(const Qubit logicalQubitIndex) {
         garbage[logicalQubitIndex] = true;
         // setting a logical qubit garbage also means removing it from the output permutation if it was present before
         for (auto it = outputPermutation.begin(); it != outputPermutation.end(); ++it) {
@@ -871,7 +861,7 @@ namespace qc {
         }
     }
 
-    [[nodiscard]] std::pair<bool, std::optional<dd::Qubit>> QuantumComputation::containsLogicalQubit(const dd::Qubit logicalQubitIndex) const {
+    [[nodiscard]] std::pair<bool, std::optional<Qubit>> QuantumComputation::containsLogicalQubit(const Qubit logicalQubitIndex) const {
         if (const auto it = std::find_if(
                     initialLayout.cbegin(),
                     initialLayout.cend(),
@@ -881,18 +871,20 @@ namespace qc {
             it != initialLayout.cend()) {
             return {true, it->first};
         }
-        return {false, {}};
+        return {false, std::nullopt};
     }
 
     bool QuantumComputation::isLastOperationOnQubit(const const_iterator& opIt, const const_iterator& end) const {
-        if (opIt == end)
+        if (opIt == end) {
             return true;
+        }
 
         // determine which qubits the gate acts on
         std::vector<bool> actson(nqubits + nancillae);
         for (std::size_t i = 0; i < actson.size(); ++i) {
-            if ((*opIt)->actsOn(static_cast<dd::Qubit>(i)))
+            if ((*opIt)->actsOn(i)) {
                 actson[i] = true;
+            }
         }
 
         // iterate over remaining gates and check if any act on qubits overlapping with the target gate
@@ -900,7 +892,9 @@ namespace qc {
         std::advance(atEnd, 1);
         while (atEnd != end) {
             for (std::size_t i = 0; i < actson.size(); ++i) {
-                if (actson[i] && (*atEnd)->actsOn(static_cast<dd::Qubit>(i))) return false;
+                if (actson[i] && (*atEnd)->actsOn(i)) {
+                    return false;
+                }
             }
             ++atEnd;
         }
@@ -936,137 +930,138 @@ namespace qc {
         }
     }
 
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit) const {
         if (const auto it = initialLayout.find(qubit); it == initialLayout.end() || it->second >= getNqubits())
             throw QFRException("Qubit index out of range: " +
                                std::to_string(qubit));
     }
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit0, const Qubit qubit1) const {
         checkQubitRange(qubit0);
         checkQubitRange(qubit1);
     }
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit, const dd::Control& control) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit, const Control& control) const {
         checkQubitRange(qubit);
         checkQubitRange(control.qubit);
     }
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1, const dd::Control& control) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit0, const Qubit qubit1, const Control& control) const {
         checkQubitRange(qubit0, qubit1);
         checkQubitRange(control.qubit);
     }
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit, const dd::Controls& controls) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit, const Controls& controls) const {
         checkQubitRange(qubit);
         for (auto& [ctrl, _]: controls)
             checkQubitRange(ctrl);
     }
 
-    void QuantumComputation::checkQubitRange(dd::Qubit qubit0, dd::Qubit qubit1, const dd::Controls& controls) const {
+    void QuantumComputation::checkQubitRange(const Qubit qubit0, const Qubit qubit1, const Controls& controls) const {
         checkQubitRange(qubit0, controls);
         checkQubitRange(qubit1);
     }
 
-    void QuantumComputation::checkQubitRange(const std::vector<dd::Qubit>& qubits) const {
+    void QuantumComputation::checkQubitRange(const std::vector<Qubit>& qubits) const {
         std::for_each(qubits.begin(), qubits.end(), [&](auto q) { checkQubitRange(q); });
     }
 
     void QuantumComputation::addVariable(const SymbolOrNumber& expr) {
         if (std::holds_alternative<Symbolic>(expr)) {
             const auto& sym = std::get<Symbolic>(expr);
-            for (const auto& term: sym)
+            for (const auto& term: sym) {
                 occuringVariables.insert(term.getVar());
+            }
         }
     }
 
-    void QuantumComputation::u3(dd::Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
+    void QuantumComputation::u3(Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
         checkQubitRange(target);
         addVariables(lambda, phi, theta);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::U3, lambda, phi, theta);
     }
-    void QuantumComputation::u3(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
+    void QuantumComputation::u3(Qubit target, const Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
         checkQubitRange(target, control);
         addVariables(lambda, phi, theta);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::U3, lambda, phi, theta);
     }
-    void QuantumComputation::u3(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
+    void QuantumComputation::u3(Qubit target, const Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta) {
         checkQubitRange(target, controls);
         addVariables(lambda, phi, theta);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::U3, lambda, phi, theta);
     }
 
-    void QuantumComputation::u2(dd::Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
+    void QuantumComputation::u2(Qubit target, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
         checkQubitRange(target);
         addVariables(lambda, phi);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::U2, lambda, phi);
     }
-    void QuantumComputation::u2(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
+    void QuantumComputation::u2(Qubit target, const Control& control, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
         checkQubitRange(target, control);
         addVariables(lambda, phi);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::U2, lambda, phi);
     }
-    void QuantumComputation::u2(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
+    void QuantumComputation::u2(Qubit target, const Controls& controls, const SymbolOrNumber& lambda, const SymbolOrNumber& phi) {
         checkQubitRange(target, controls);
         addVariables(lambda, phi);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::U2, lambda, phi);
     }
 
-    void QuantumComputation::phase(dd::Qubit target, const SymbolOrNumber& lambda) {
+    void QuantumComputation::phase(Qubit target, const SymbolOrNumber& lambda) {
         checkQubitRange(target);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::Phase, lambda);
     }
-    void QuantumComputation::phase(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda) {
+    void QuantumComputation::phase(Qubit target, const Control& control, const SymbolOrNumber& lambda) {
         checkQubitRange(target, control);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::Phase, lambda);
     }
-    void QuantumComputation::phase(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda) {
+    void QuantumComputation::phase(Qubit target, const Controls& controls, const SymbolOrNumber& lambda) {
         checkQubitRange(target, controls);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::Phase, lambda);
     }
 
-    void QuantumComputation::rx(dd::Qubit target, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rx(Qubit target, const SymbolOrNumber& lambda) {
         checkQubitRange(target);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::RX, lambda);
     }
-    void QuantumComputation::rx(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rx(Qubit target, const Control& control, const SymbolOrNumber& lambda) {
         checkQubitRange(target, control);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::RX, lambda);
     }
-    void QuantumComputation::rx(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rx(Qubit target, const Controls& controls, const SymbolOrNumber& lambda) {
         checkQubitRange(target, controls);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::RX, lambda);
     }
 
-    void QuantumComputation::ry(dd::Qubit target, const SymbolOrNumber& lambda) {
+    void QuantumComputation::ry(Qubit target, const SymbolOrNumber& lambda) {
         checkQubitRange(target);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::RY, lambda);
     }
-    void QuantumComputation::ry(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda) {
+    void QuantumComputation::ry(Qubit target, const Control& control, const SymbolOrNumber& lambda) {
         checkQubitRange(target, control);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::RY, lambda);
     }
-    void QuantumComputation::ry(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda) {
+    void QuantumComputation::ry(Qubit target, const Controls& controls, const SymbolOrNumber& lambda) {
         checkQubitRange(target, controls);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::RY, lambda);
     }
 
-    void QuantumComputation::rz(dd::Qubit target, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rz(Qubit target, const SymbolOrNumber& lambda) {
         checkQubitRange(target);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), target, qc::RZ, lambda);
     }
-    void QuantumComputation::rz(dd::Qubit target, const dd::Control& control, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rz(Qubit target, const Control& control, const SymbolOrNumber& lambda) {
         checkQubitRange(target, control);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), control, target, qc::RZ, lambda);
     }
-    void QuantumComputation::rz(dd::Qubit target, const dd::Controls& controls, const SymbolOrNumber& lambda) {
+    void QuantumComputation::rz(Qubit target, const Controls& controls, const SymbolOrNumber& lambda) {
         checkQubitRange(target, controls);
         addVariables(lambda);
         emplace_back<SymbolicOperation>(getNqubits(), controls, target, qc::RZ, lambda);

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -717,13 +717,13 @@ namespace qc {
                 if (reduceIOpermutations && (logicalQubitIndex < nqubits + nancillae)) {
                     for (auto& q: initialLayout) {
                         if (q.second > logicalQubitIndex) {
-                            q.second--;
+                            --q.second;
                         }
                     }
 
                     for (auto& q: outputPermutation) {
                         if (q.second > logicalQubitIndex) {
-                            q.second--;
+                            --q.second;
                         }
                     }
                 }
@@ -768,9 +768,9 @@ namespace qc {
         if (it != qregs.end()) {
             index = static_cast<Qubit>(physicalQubitIndex - it->second.first);
         } else {
-            auto it_anc = ancregs.find(regName);
-            if (it_anc != ancregs.end()) {
-                index = static_cast<Qubit>(physicalQubitIndex - it_anc->second.first);
+            auto itAnc = ancregs.find(regName);
+            if (itAnc != ancregs.end()) {
+                index = static_cast<Qubit>(physicalQubitIndex - itAnc->second.first);
             }
             // no else branch needed here, since error would have already shown in getQubitRegister(physicalQubitIndex)
         }
@@ -794,9 +794,9 @@ namespace qc {
     }
 
     std::pair<std::string, Bit> QuantumComputation::getClassicalRegisterAndIndex(const Bit classicalIndex) const {
-        std::string regName = getClassicalRegister(classicalIndex);
-        std::size_t index   = 0;
-        auto        it      = cregs.find(regName);
+        const std::string regName = getClassicalRegister(classicalIndex);
+        std::size_t       index   = 0;
+        auto              it      = cregs.find(regName);
         if (it != cregs.end()) {
             index = classicalIndex - it->second.first;
         } // else branch not needed since getClassicalRegister already covers this case

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -6,35 +6,37 @@
 #include "algorithms/BernsteinVazirani.hpp"
 
 namespace qc {
-    BernsteinVazirani::BernsteinVazirani(const BitString& s, bool dynamic):
+    BernsteinVazirani::BernsteinVazirani(const BitString& s, const bool dynamic):
         s(s), dynamic(dynamic) {
-        dd::QubitCount msb = 0;
+        Qubit msb = 0;
         for (std::size_t i = 0; i < s.size(); ++i) {
-            if (s.test(i))
+            if (s.test(i)) {
                 msb = i;
+            }
         }
         bitwidth = msb + 1;
         createCircuit();
     }
 
-    BernsteinVazirani::BernsteinVazirani(dd::QubitCount nq, bool dynamic):
+    BernsteinVazirani::BernsteinVazirani(const std::size_t nq, const bool dynamic):
         bitwidth(nq), dynamic(dynamic) {
         auto distribution = std::bernoulli_distribution();
-        for (dd::QubitCount i = 0; i < nq; ++i) {
-            if (distribution(mt))
+        for (std::size_t i = 0; i < nq; ++i) {
+            if (distribution(mt)) {
                 s.set(i);
+            }
         }
         createCircuit();
     }
 
-    BernsteinVazirani::BernsteinVazirani(const BitString& s, dd::QubitCount nq, bool dynamic):
+    BernsteinVazirani::BernsteinVazirani(const BitString& s, const std::size_t nq, const bool dynamic):
         s(s), bitwidth(nq), dynamic(dynamic) {
         createCircuit();
     }
 
     std::ostream& BernsteinVazirani::printStatistics(std::ostream& os) const {
-        os << "BernsteinVazirani (" << static_cast<std::size_t>(bitwidth) << ") Statistics:\n";
-        os << "\tn: " << static_cast<std::size_t>(bitwidth + 1) << std::endl;
+        os << "BernsteinVazirani (" << bitwidth << ") Statistics:\n";
+        os << "\tn: " << bitwidth + 1 << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\ts: " << expected << std::endl;
         os << "\tdynamic: " << dynamic << std::endl;
@@ -47,8 +49,9 @@ namespace qc {
 
         expected = s.to_string();
         std::reverse(expected.begin(), expected.end());
-        while (expected.length() > bitwidth)
+        while (expected.length() > bitwidth) {
             expected.pop_back();
+        }
         std::reverse(expected.begin(), expected.end());
 
         addQubitRegister(1, "flag");
@@ -65,13 +68,14 @@ namespace qc {
         x(0);
 
         if (dynamic) {
-            for (dd::QubitCount i = 0; i < bitwidth; ++i) {
+            for (std::size_t i = 0; i < bitwidth; ++i) {
                 // initial Hadamard
                 h(1);
 
                 // apply controlled-Z gate according to secret bitstring
-                if (s.test(i))
+                if (s.test(i)) {
                     z(0, 1_pc);
+                }
 
                 // final Hadamard
                 h(1);
@@ -80,29 +84,31 @@ namespace qc {
                 measure(1, i);
 
                 // reset qubit if not finished
-                if (i < bitwidth - 1)
+                if (i < bitwidth - 1) {
                     reset(1);
+                }
             }
         } else {
             // initial Hadamard transformation
-            for (dd::QubitCount i = 1; i <= bitwidth; ++i) {
-                h(static_cast<dd::Qubit>(i));
+            for (std::size_t i = 1; i <= bitwidth; ++i) {
+                h(i);
             }
 
             // apply controlled-Z gates according to secret bitstring
-            for (dd::QubitCount i = 1; i <= bitwidth; ++i) {
-                if (s.test(i - 1))
-                    z(0, dd::Control{static_cast<dd::Qubit>(i)});
+            for (std::size_t i = 1; i <= bitwidth; ++i) {
+                if (s.test(i - 1)) {
+                    z(0, qc::Control{static_cast<Qubit>(i)});
+                }
             }
 
             // final Hadamard transformation
-            for (dd::QubitCount i = 1; i <= bitwidth; ++i) {
-                h(static_cast<dd::Qubit>(i));
+            for (std::size_t i = 1; i <= bitwidth; ++i) {
+                h(i);
             }
 
             // measure results
-            for (dd::QubitCount i = 1; i <= bitwidth; i++) {
-                measure(static_cast<dd::Qubit>(i), i - 1);
+            for (std::size_t i = 1; i <= bitwidth; i++) {
+                measure(i, i - 1);
             }
         }
     }

--- a/src/algorithms/Entanglement.cpp
+++ b/src/algorithms/Entanglement.cpp
@@ -5,17 +5,15 @@
 
 #include "algorithms/Entanglement.hpp"
 
-using namespace dd::literals;
-
 namespace qc {
-    Entanglement::Entanglement(dd::QubitCount nq):
+    Entanglement::Entanglement(const std::size_t nq):
         QuantumComputation(nq) {
         name           = "entanglement_" + std::to_string(nq);
-        const auto top = static_cast<dd::Qubit>(nq - 1);
+        const auto top = static_cast<Qubit>(nq - 1);
 
         h(top);
-        for (dd::QubitCount i = 1; i < nq; i++) {
-            x(static_cast<dd::Qubit>(top - i), dd::Control{top});
+        for (std::size_t i = 1; i < nq; i++) {
+            x(static_cast<Qubit>(top - i), qc::Control{top});
         }
     }
 } // namespace qc

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -10,44 +10,45 @@ namespace qc {
      * Private Methods
      ***/
     void Grover::setup(QuantumComputation& qc) const {
-        qc.x(static_cast<dd::Qubit>(nDataQubits));
-        for (dd::QubitCount i = 0; i < nDataQubits; ++i)
-            qc.h(static_cast<dd::Qubit>(i));
-    }
-
-    void Grover::oracle(QuantumComputation& qc) const {
-        dd::Controls controls{};
-        for (dd::QubitCount i = 0; i < nDataQubits; ++i) {
-            controls.emplace(dd::Control{static_cast<dd::Qubit>(i), targetValue.test(i) ? dd::Control::Type::pos : dd::Control::Type::neg});
-        }
-        qc.z(static_cast<dd::Qubit>(nDataQubits), controls);
-    }
-
-    void Grover::diffusion(QuantumComputation& qc) const {
-        for (dd::QubitCount i = 0; i < nDataQubits; ++i) {
-            qc.h(static_cast<dd::Qubit>(i));
-        }
-        for (dd::QubitCount i = 0; i < nDataQubits; ++i) {
-            qc.x(static_cast<dd::Qubit>(i));
-        }
-
-        qc.h(0);
-        dd::Controls controls{};
-        for (dd::Qubit j = 1; j < nDataQubits; ++j) {
-            controls.emplace(dd::Control{j});
-        }
-        qc.x(0, controls);
-        qc.h(0);
-
-        for (auto i = static_cast<dd::Qubit>(nDataQubits - 1); i >= 0; --i) {
-            qc.x(i);
-        }
-        for (auto i = static_cast<dd::Qubit>(nDataQubits - 1); i >= 0; --i) {
+        qc.x(nDataQubits);
+        for (std::size_t i = 0; i < nDataQubits; ++i) {
             qc.h(i);
         }
     }
 
-    void Grover::full_grover(QuantumComputation& qc) const {
+    void Grover::oracle(QuantumComputation& qc) const {
+        Controls controls{};
+        for (std::size_t i = 0; i < nDataQubits; ++i) {
+            controls.emplace(Control{static_cast<Qubit>(i), targetValue.test(i) ? Control::Type::Pos : Control::Type::Neg});
+        }
+        qc.z(nDataQubits, controls);
+    }
+
+    void Grover::diffusion(QuantumComputation& qc) const {
+        for (std::size_t i = 0; i < nDataQubits; ++i) {
+            qc.h(i);
+        }
+        for (std::size_t i = 0; i < nDataQubits; ++i) {
+            qc.x(i);
+        }
+
+        qc.h(0);
+        Controls controls{};
+        for (Qubit j = 1; j < nDataQubits; ++j) {
+            controls.emplace(Control{j});
+        }
+        qc.x(0, controls);
+        qc.h(0);
+
+        for (auto i = static_cast<std::make_signed_t<Qubit>>(nDataQubits - 1); i >= 0; --i) {
+            qc.x(i);
+        }
+        for (auto i = static_cast<std::make_signed_t<Qubit>>(nDataQubits - 1); i >= 0; --i) {
+            qc.h(i);
+        }
+    }
+
+    void Grover::fullGrover(QuantumComputation& qc) const {
         // create initial superposition
         setup(qc);
 
@@ -58,14 +59,15 @@ namespace qc {
         }
 
         // measure the resulting state
-        for (dd::QubitCount i = 0; i < nDataQubits; ++i)
-            qc.measure(static_cast<dd::Qubit>(i), i);
+        for (std::size_t i = 0; i < nDataQubits; ++i) {
+            qc.measure(i, i);
+        }
     }
 
     /***
      * Public Methods
      ***/
-    Grover::Grover(dd::QubitCount nq, std::size_t seed):
+    Grover::Grover(std::size_t nq, std::size_t seed):
         seed(seed), nDataQubits(nq) {
         name = "grover_" + std::to_string(nq);
 
@@ -84,24 +86,25 @@ namespace qc {
 
         expected = targetValue.to_string();
         std::reverse(expected.begin(), expected.end());
-        while (expected.length() > static_cast<std::size_t>(nqubits - 1))
+        while (expected.length() > static_cast<std::size_t>(nqubits - 1)) {
             expected.pop_back();
+        }
         std::reverse(expected.begin(), expected.end());
 
         if (nDataQubits <= 2) {
             iterations = 1;
         } else if (nDataQubits % 2 == 1) {
-            iterations = static_cast<std::size_t>(std::round(dd::PI_4 * std::pow(2.L, (nDataQubits + 1.) / 2.L - 1.) * std::sqrt(2)));
+            iterations = static_cast<std::size_t>(std::round(PI_4 * std::pow(2.L, (nDataQubits + 1.) / 2.L - 1.) * std::sqrt(2)));
         } else {
-            iterations = static_cast<std::size_t>(std::round(dd::PI_4 * std::pow(2.L, (nDataQubits) / 2.L)));
+            iterations = static_cast<std::size_t>(std::round(PI_4 * std::pow(2.L, (nDataQubits) / 2.L)));
         }
 
-        full_grover(*this);
+        fullGrover(*this);
     }
 
     std::ostream& Grover::printStatistics(std::ostream& os) const {
-        os << "Grover (" << static_cast<std::size_t>(nqubits - 1) << ") Statistics:\n";
-        os << "\tn: " << static_cast<std::size_t>(nqubits) << std::endl;
+        os << "Grover (" << nqubits - 1 << ") Statistics:\n";
+        os << "\tn: " << nqubits << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\tseed: " << seed << std::endl;
         os << "\tx: " << expected << std::endl;

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -6,9 +6,9 @@
 #include "algorithms/QFT.hpp"
 
 namespace qc {
-    QFT::QFT(dd::QubitCount nq, bool includeMeasurements, bool dynamic):
+    QFT::QFT(const std::size_t nq, const bool includeMeasurements, const bool dynamic):
         precision(nq), includeMeasurements(includeMeasurements), dynamic(dynamic) {
-        name = "qft_" + std::to_string(static_cast<std::size_t>(nq));
+        name = "qft_" + std::to_string(nq);
         if (precision == 0) {
             return;
         }
@@ -23,8 +23,8 @@ namespace qc {
     }
 
     std::ostream& QFT::printStatistics(std::ostream& os) const {
-        os << "QFT (" << static_cast<std::size_t>(precision) << ") Statistics:\n";
-        os << "\tn: " << static_cast<std::size_t>(nqubits) << std::endl;
+        os << "QFT (" << precision << ") Statistics:\n";
+        os << "\tn: " << nqubits << std::endl;
         os << "\tm: " << getNindividualOps() << std::endl;
         os << "\tdynamic: " << dynamic << std::endl;
         os << "--------------" << std::endl;
@@ -32,17 +32,17 @@ namespace qc {
     }
     void QFT::createCircuit() {
         if (dynamic) {
-            for (dd::QubitCount i = 0; i < precision; i++) {
+            for (std::size_t i = 0; i < precision; i++) {
                 // apply classically controlled phase rotations
-                for (dd::QubitCount j = 1; j <= i; ++j) {
-                    const auto d = static_cast<dd::Qubit>(precision - j);
+                for (std::size_t j = 1; j <= i; ++j) {
+                    const auto d = static_cast<Qubit>(precision - j);
                     if (j == i) {
                         classicControlled(S, 0, {d, 1U}, 1U);
                     } else if (j == i - 1) {
                         classicControlled(T, 0, {d, 1U}, 1U);
                     } else {
                         auto powerOfTwo = std::pow(2.L, i - j + 1);
-                        auto lambda     = static_cast<dd::fp>(dd::PI / powerOfTwo);
+                        auto lambda     = static_cast<fp>(PI / powerOfTwo);
                         classicControlled(Phase, 0, {d, 1U}, 1U, lambda);
                     }
                 }
@@ -54,25 +54,26 @@ namespace qc {
                 measure(0, precision - 1 - i);
 
                 // reset qubit if not finished
-                if (i < precision - 1)
+                if (i < precision - 1) {
                     reset(0);
+                }
             }
         } else {
             // apply quantum Fourier transform
-            for (dd::QubitCount i = 0; i < precision; ++i) {
-                const auto q = static_cast<dd::Qubit>(i);
+            for (std::size_t i = 0; i < precision; ++i) {
+                const auto q = static_cast<Qubit>(i);
 
                 // apply controlled rotations
-                for (dd::QubitCount j = i; j > 0; --j) {
-                    const auto d = static_cast<dd::Qubit>(q - j);
+                for (std::size_t j = i; j > 0; --j) {
+                    const auto d = static_cast<Qubit>(q - j);
                     if (j == 1) {
-                        s(d, dd::Control{q});
+                        s(d, Control{q});
                     } else if (j == 2) {
-                        t(d, dd::Control{q});
+                        t(d, Control{q});
                     } else {
                         auto powerOfTwo = std::pow(2.L, j);
-                        auto lambda     = static_cast<dd::fp>(dd::PI / powerOfTwo);
-                        phase(d, dd::Control{q}, lambda);
+                        auto lambda     = static_cast<fp>(PI / powerOfTwo);
+                        phase(d, Control{q}, lambda);
                     }
                 }
 
@@ -82,15 +83,15 @@ namespace qc {
 
             if (includeMeasurements) {
                 // measure qubits in reverse order
-                for (dd::QubitCount i = 0; i < precision; ++i) {
-                    measure(static_cast<dd::Qubit>(i), precision - 1 - i);
+                for (std::size_t i = 0; i < precision; ++i) {
+                    measure(i, precision - 1 - i);
                 }
             } else {
-                for (dd::Qubit i = 0; i < static_cast<dd::Qubit>(precision / 2); ++i) {
-                    swap(i, static_cast<dd::Qubit>(precision - 1 - i));
+                for (Qubit i = 0; i < static_cast<Qubit>(precision / 2); ++i) {
+                    swap(i, static_cast<Qubit>(precision - 1 - i));
                 }
-                for (dd::QubitCount i = 0; i < precision; ++i) {
-                    outputPermutation[static_cast<dd::Qubit>(i)] = static_cast<dd::Qubit>(precision - 1 - i);
+                for (std::size_t i = 0; i < precision; ++i) {
+                    outputPermutation[i] = static_cast<Qubit>(precision - 1 - i);
                 }
             }
         }

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -6,33 +6,33 @@
 #include "algorithms/QPE.hpp"
 
 namespace qc {
-    QPE::QPE(dd::QubitCount nq, bool exact, bool iterative):
+    QPE::QPE(const std::size_t nq, const bool exact, const bool iterative):
         precision(nq), iterative(iterative) {
         if (exact) {
             // if an exact solution is wanted, generate a random n-bit number and convert it to an appropriate phase
-            std::uint_least64_t max          = 1ULL << nq;
-            auto                distribution = std::uniform_int_distribution<std::uint_least64_t>(0, max - 1);
-            std::uint_least64_t theta        = 0;
+            const std::uint64_t max          = 1ULL << nq;
+            auto                distribution = std::uniform_int_distribution<std::uint64_t>(0, max - 1);
+            std::uint64_t       theta        = 0;
             while (theta == 0) {
                 theta = distribution(mt);
             }
             lambda = 0.;
             for (std::size_t i = 0; i < nq; ++i) {
-                if (theta & (1ULL << (nq - i - 1))) {
+                if ((theta & (1ULL << (nq - i - 1))) != 0) {
                     lambda += 1. / static_cast<double>(1ULL << i);
                 }
             }
         } else {
             // if an inexact solution is wanted, generate a random n+1-bit number (that has its last bit set) and convert it to an appropriate phase
-            std::uint_least64_t max          = 1ULL << (nq + 1);
-            auto                distribution = std::uniform_int_distribution<std::uint_least64_t>(0, max - 1);
-            std::uint_least64_t theta        = 0;
+            const std::uint64_t max          = 1ULL << (nq + 1);
+            auto                distribution = std::uniform_int_distribution<std::uint64_t>(0, max - 1);
+            std::uint64_t       theta        = 0;
             while (theta == 0 && (theta & 1) == 0) {
                 theta = distribution(mt);
             }
             lambda = 0.;
             for (std::size_t i = 0; i <= nq; ++i) {
-                if (theta & (1ULL << (nq - i))) {
+                if ((theta & (1ULL << (nq - i))) != 0) {
                     lambda += 1. / static_cast<double>(1ULL << i);
                 }
             }
@@ -40,7 +40,7 @@ namespace qc {
         createCircuit();
     }
 
-    QPE::QPE(dd::fp lambda, dd::QubitCount precision, bool iterative):
+    QPE::QPE(const fp lambda, const std::size_t precision, const bool iterative):
         lambda(lambda), precision(precision), iterative(iterative) {
         createCircuit();
     }
@@ -71,7 +71,7 @@ namespace qc {
         x(0);
 
         if (iterative) {
-            for (dd::QubitCount i = 0; i < precision; i++) {
+            for (std::size_t i = 0; i < precision; i++) {
                 // Hadamard
                 h(1);
 
@@ -79,12 +79,12 @@ namespace qc {
                 const auto angle = std::remainder(static_cast<double>(1ULL << (precision - 1 - i)) * lambda, 2.0);
 
                 // controlled phase rotation
-                phase(0, 1_pc, angle * dd::PI);
+                phase(0, 1_pc, angle * PI);
 
                 // hybrid quantum-classical inverse QFT
-                for (dd::QubitCount j = 0; j < i; j++) {
-                    auto iQFT_lambda = -dd::PI / static_cast<double>(1ULL << (i - j));
-                    classicControlled(Phase, 1, {j, 1U}, 1U, iQFT_lambda);
+                for (std::size_t j = 0; j < i; j++) {
+                    auto iQFTLambda = -PI / static_cast<double>(1ULL << (i - j));
+                    classicControlled(Phase, 1, {j, 1U}, 1U, iQFTLambda);
                 }
                 h(1);
 
@@ -92,39 +92,40 @@ namespace qc {
                 measure(1, i);
 
                 // reset qubit if not finished
-                if (i < precision - 1)
+                if (i < precision - 1) {
                     reset(1);
+                }
             }
         } else {
             // Hadamard Layer
-            for (dd::QubitCount i = 1; i <= precision; i++) {
-                h(static_cast<dd::Qubit>(i));
+            for (std::size_t i = 1; i <= precision; i++) {
+                h(i);
             }
 
-            for (dd::QubitCount i = 0; i < precision; i++) {
+            for (std::size_t i = 0; i < precision; i++) {
                 // normalize angle
                 const auto angle = std::remainder(static_cast<double>(1ULL << (precision - 1 - i)) * lambda, 2.0);
 
                 // controlled phase rotation
-                phase(0, dd::Control{static_cast<dd::Qubit>(1 + i)}, angle * dd::PI);
+                phase(0, Control{static_cast<Qubit>(1 + i)}, angle * PI);
 
                 // inverse QFT
-                for (dd::QubitCount j = 1; j < 1 + i; j++) {
-                    auto iQFT_lambda = -dd::PI / static_cast<double>(2ULL << (i - j));
+                for (std::size_t j = 1; j < 1 + i; j++) {
+                    auto iQFTLambda = -PI / static_cast<double>(2ULL << (i - j));
                     if (j == i) {
-                        sdag(static_cast<dd::Qubit>(1 + i), dd::Control{static_cast<dd::Qubit>(i)});
+                        sdag(1 + i, Control{static_cast<Qubit>(i)});
                     } else if (j == i - 1) {
-                        tdag(static_cast<dd::Qubit>(1 + i), dd::Control{static_cast<dd::Qubit>(i - 1)});
+                        tdag(1 + i, Control{static_cast<Qubit>(i - 1)});
                     } else {
-                        phase(static_cast<dd::Qubit>(1 + i), dd::Control{static_cast<dd::Qubit>(j)}, iQFT_lambda);
+                        phase(1 + i, Control{static_cast<Qubit>(j)}, iQFTLambda);
                     }
                 }
-                h(static_cast<dd::Qubit>(1 + i));
+                h(1 + i);
             }
 
             // measure results
-            for (dd::QubitCount i = 0; i < nqubits - 1; i++) {
-                measure(static_cast<dd::Qubit>(i + 1), i);
+            for (std::size_t i = 0; i < nqubits - 1; i++) {
+                measure(i + 1, i);
             }
         }
     }

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -6,6 +6,7 @@
 #include "operations/NonUnitaryOperation.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <utility>
 
 namespace qc {

--- a/src/operations/Operation.cpp
+++ b/src/operations/Operation.cpp
@@ -118,23 +118,23 @@ namespace qc {
 
         bool isZero = true;
         for (size_t i = 0; i < MAX_PARAMETERS; ++i) {
-            if (parameter[i] != 0.L)
+            if (parameter[i] != 0.L) {
                 isZero = false;
+            }
         }
         if (!isZero) {
-            os << "\tp: (";
-            dd::ComplexValue::printFormatted(os, parameter[0]);
-            os << ") ";
+            os << "\tp: (" << parameter[0] << ") ";
             for (size_t j = 1; j < MAX_PARAMETERS; ++j) {
                 isZero = true;
                 for (size_t i = j; i < MAX_PARAMETERS; ++i) {
-                    if (parameter[i] != 0.L)
+                    if (parameter[i] != 0.L) {
                         isZero = false;
+                    }
                 }
-                if (isZero) break;
-                os << "(";
-                dd::ComplexValue::printFormatted(os, parameter[j]);
-                os << ") ";
+                if (isZero) {
+                    break;
+                }
+                os << "(" << parameter[j] << ") ";
             }
         }
 
@@ -142,14 +142,14 @@ namespace qc {
     }
 
     std::ostream& Operation::print(std::ostream& os) const {
-        const auto prec_before = std::cout.precision(20);
+        const auto precBefore = std::cout.precision(20);
 
         os << std::setw(4) << name << "\t";
 
         auto controlIt = controls.begin();
         auto targetIt  = targets.begin();
-        for (dd::QubitCount i = 0; i < nqubits; ++i) {
-            if (targetIt != targets.end() && *targetIt == static_cast<dd::Qubit>(i)) {
+        for (std::size_t i = 0; i < nqubits; ++i) {
+            if (targetIt != targets.end() && *targetIt == i) {
                 if (type == ClassicControlled) {
                     os << "\033[1m\033[35m" << name[2] << name[3];
                 } else {
@@ -157,8 +157,8 @@ namespace qc {
                 }
                 os << "\t\033[0m";
                 ++targetIt;
-            } else if (controlIt != controls.end() && controlIt->qubit == static_cast<dd::Qubit>(i)) {
-                if (controlIt->type == dd::Control::Type::pos) {
+            } else if (controlIt != controls.end() && controlIt->qubit == i) {
+                if (controlIt->type == Control::Type::Pos) {
                     os << "\033[32m";
                 } else {
                     os << "\033[31m";
@@ -173,13 +173,13 @@ namespace qc {
 
         printParameters(os);
 
-        std::cout.precision(prec_before);
+        std::cout.precision(precBefore);
 
         return os;
     }
 
     std::ostream& Operation::print(std::ostream& os, const Permutation& permutation) const {
-        const auto prec_before = std::cout.precision(20);
+        const auto precBefore = std::cout.precision(20);
 
         os << std::setw(4) << name << "\t";
         const auto& actualControls = getControls();
@@ -196,7 +196,7 @@ namespace qc {
                 os << "\t\033[0m";
                 ++targetIt;
             } else if (controlIt != actualControls.cend() && controlIt->qubit == physical) {
-                if (controlIt->type == dd::Control::Type::pos) {
+                if (controlIt->type == Control::Type::Pos) {
                     os << "\033[32m";
                 } else {
                     os << "\033[31m";
@@ -211,7 +211,7 @@ namespace qc {
 
         printParameters(os);
 
-        std::cout.precision(prec_before);
+        std::cout.precision(precBefore);
 
         return os;
     }
@@ -241,21 +241,21 @@ namespace qc {
 
         // check controls
         if (nc1 != 0U) {
-            dd::Controls controls1{};
+            Controls controls1{};
             if (perm1.empty()) {
                 controls1 = getControls();
             } else {
                 for (const auto& control: getControls()) {
-                    controls1.emplace(dd::Control{perm1.at(control.qubit), control.type});
+                    controls1.emplace(Control{perm1.at(control.qubit), control.type});
                 }
             }
 
-            dd::Controls controls2{};
+            Controls controls2{};
             if (perm2.empty()) {
                 controls2 = op.getControls();
             } else {
                 for (const auto& control: op.getControls()) {
-                    controls2.emplace(dd::Control{perm2.at(control.qubit), control.type});
+                    controls2.emplace(Control{perm2.at(control.qubit), control.type});
                 }
             }
 
@@ -265,7 +265,7 @@ namespace qc {
         }
 
         // check targets
-        std::set<dd::Qubit> targets1{};
+        std::set<Qubit> targets1{};
         if (perm1.empty()) {
             targets1 = {getTargets().begin(), getTargets().end()};
         } else {
@@ -274,7 +274,7 @@ namespace qc {
             }
         }
 
-        std::set<dd::Qubit> targets2{};
+        std::set<Qubit> targets2{};
         if (perm2.empty()) {
             targets2 = {op.getTargets().begin(), op.getTargets().end()};
         } else {

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -5,24 +5,26 @@
 
 #include "operations/StandardOperation.hpp"
 
+#include <sstream>
 #include <variant>
 
 namespace qc {
     /***
      * Protected Methods
      ***/
-    OpType StandardOperation::parseU3(dd::fp& lambda, dd::fp& phi, dd::fp& theta) {
+    OpType StandardOperation::parseU3(fp& lambda, fp& phi, fp& theta) {
         if (std::abs(theta) < PARAMETER_TOLERANCE && std::abs(phi) < PARAMETER_TOLERANCE) {
             phi   = 0.L;
             theta = 0.L;
             return parseU1(lambda);
         }
 
-        if (std::abs(theta - dd::PI_2) < PARAMETER_TOLERANCE) {
-            theta    = dd::PI_2;
+        if (std::abs(theta - PI_2) < PARAMETER_TOLERANCE) {
+            theta    = PI_2;
             auto res = parseU2(lambda, phi);
-            if (res != U2)
+            if (res != U2) {
                 theta = 0.L;
+            }
             return res;
         }
 
@@ -38,9 +40,9 @@ namespace qc {
             }
         }
 
-        if (std::abs(lambda - dd::PI_2) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI_2;
-            if (std::abs(phi + dd::PI_2) < PARAMETER_TOLERANCE) {
+        if (std::abs(lambda - PI_2) < PARAMETER_TOLERANCE) {
+            lambda = PI_2;
+            if (std::abs(phi + PI_2) < PARAMETER_TOLERANCE) {
                 phi = 0.L;
                 checkInteger(theta);
                 checkFractionPi(theta);
@@ -49,9 +51,9 @@ namespace qc {
                 return RX;
             }
 
-            if (std::abs(phi - dd::PI_2) < PARAMETER_TOLERANCE) {
-                phi = dd::PI_2;
-                if (std::abs(theta - dd::PI) < PARAMETER_TOLERANCE) {
+            if (std::abs(phi - PI_2) < PARAMETER_TOLERANCE) {
+                phi = PI_2;
+                if (std::abs(theta - PI) < PARAMETER_TOLERANCE) {
                     lambda = 0.L;
                     phi    = 0.L;
                     theta  = 0.L;
@@ -60,11 +62,11 @@ namespace qc {
             }
         }
 
-        if (std::abs(lambda - dd::PI) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI;
+        if (std::abs(lambda - PI) < PARAMETER_TOLERANCE) {
+            lambda = PI;
             if (std::abs(phi) < PARAMETER_TOLERANCE) {
                 phi = 0.L;
-                if (std::abs(theta - dd::PI) < PARAMETER_TOLERANCE) {
+                if (std::abs(theta - PI) < PARAMETER_TOLERANCE) {
                     theta  = 0.L;
                     lambda = 0.L;
                     return X;
@@ -83,22 +85,22 @@ namespace qc {
         return U3;
     }
 
-    OpType StandardOperation::parseU2(dd::fp& lambda, dd::fp& phi) {
+    OpType StandardOperation::parseU2(fp& lambda, fp& phi) {
         if (std::abs(phi) < PARAMETER_TOLERANCE) {
             phi = 0.L;
-            if (std::abs(std::abs(lambda) - dd::PI) < PARAMETER_TOLERANCE) {
+            if (std::abs(std::abs(lambda) - PI) < PARAMETER_TOLERANCE) {
                 lambda = 0.L;
                 return H;
             }
             if (std::abs(lambda) < PARAMETER_TOLERANCE) {
-                lambda = dd::PI_2;
+                lambda = PI_2;
                 return RY;
             }
         }
 
-        if (std::abs(lambda - dd::PI_2) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI_2;
-            if (std::abs(phi + dd::PI_2) < PARAMETER_TOLERANCE) {
+        if (std::abs(lambda - PI_2) < PARAMETER_TOLERANCE) {
+            lambda = PI_2;
+            if (std::abs(phi + PI_2) < PARAMETER_TOLERANCE) {
                 phi = 0.L;
                 return RX;
             }
@@ -112,24 +114,24 @@ namespace qc {
         return U2;
     }
 
-    OpType StandardOperation::parseU1(dd::fp& lambda) {
+    OpType StandardOperation::parseU1(fp& lambda) {
         if (std::abs(lambda) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
             return I;
         }
-        bool sign = std::signbit(lambda);
+        const bool sign = std::signbit(lambda);
 
-        if (std::abs(std::abs(lambda) - dd::PI) < PARAMETER_TOLERANCE) {
+        if (std::abs(std::abs(lambda) - PI) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
             return Z;
         }
 
-        if (std::abs(std::abs(lambda) - dd::PI_2) < PARAMETER_TOLERANCE) {
+        if (std::abs(std::abs(lambda) - PI_2) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
             return sign ? Sdag : S;
         }
 
-        if (std::abs(std::abs(lambda) - dd::PI_4) < PARAMETER_TOLERANCE) {
+        if (std::abs(std::abs(lambda) - PI_4) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
             return sign ? Tdag : T;
         }
@@ -150,7 +152,7 @@ namespace qc {
         }
     }
 
-    void StandardOperation::setup(dd::QubitCount nq, dd::fp par0, dd::fp par1, dd::fp par2, dd::Qubit startingQubit) {
+    void StandardOperation::setup(const std::size_t nq, const fp par0, const fp par1, const fp par2, const Qubit startingQubit) {
         nqubits      = nq;
         parameter[0] = par0;
         parameter[1] = par1;
@@ -163,45 +165,45 @@ namespace qc {
     /***
      * Constructors
      ***/
-    StandardOperation::StandardOperation(dd::QubitCount nq, dd::Qubit target, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit) {
+    StandardOperation::StandardOperation(const std::size_t nq, const Qubit target, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit) {
         type = g;
         setup(nq, lambda, phi, theta, startingQubit);
         targets.emplace_back(target);
     }
 
-    StandardOperation::StandardOperation(dd::QubitCount nq, const Targets& targets, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit) {
+    StandardOperation::StandardOperation(const std::size_t nq, const Targets& targets, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit) {
         type = g;
         setup(nq, lambda, phi, theta, startingQubit);
         this->targets = targets;
     }
 
-    StandardOperation::StandardOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Control control, const Qubit target, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit):
         StandardOperation(nq, target, g, lambda, phi, theta, startingQubit) {
         controls.insert(control);
     }
 
-    StandardOperation::StandardOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Control control, const Targets& targets, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit):
         StandardOperation(nq, targets, g, lambda, phi, theta, startingQubit) {
         controls.insert(control);
     }
 
-    StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Controls& controls, const Qubit target, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit):
         StandardOperation(nq, target, g, lambda, phi, theta, startingQubit) {
         this->controls = controls;
     }
 
-    StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Controls& controls, const Targets& targets, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit):
         StandardOperation(nq, targets, g, lambda, phi, theta, startingQubit) {
         this->controls = controls;
     }
 
     // MCT Constructor
-    StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Controls& controls, const Qubit target, const Qubit startingQubit):
         StandardOperation(nq, controls, target, X, 0., 0., 0., startingQubit) {
     }
 
     // MCF (cSWAP), Peres, paramterized two target Constructor
-    StandardOperation::StandardOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, OpType g, dd::fp lambda, dd::fp phi, dd::fp theta, dd::Qubit startingQubit):
+    StandardOperation::StandardOperation(const std::size_t nq, const Controls& controls, const Qubit target0, const Qubit target1, const OpType g, const fp lambda, const fp phi, const fp theta, const Qubit startingQubit):
         StandardOperation(nq, controls, {target0, target1}, g, lambda, phi, theta, startingQubit) {
     }
 
@@ -210,7 +212,7 @@ namespace qc {
     ***/
     void StandardOperation::dumpOpenQASM(std::ostream& of, const RegisterNames& qreg, [[maybe_unused]] const RegisterNames& creg) const {
         std::ostringstream op;
-        op << std::setprecision(std::numeric_limits<dd::fp>::digits10);
+        op << std::setprecision(std::numeric_limits<fp>::digits10);
         if ((controls.size() > 1 && type != X) || controls.size() > 2) {
             std::cout << "[WARNING] Multiple controlled gates are not natively supported by OpenQASM. "
                       << "However, this library can parse .qasm files with multiple controlled gates (e.g., cccx) correctly. "
@@ -335,7 +337,7 @@ namespace qc {
 
         // apply X operations to negate the respective controls
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }
@@ -350,7 +352,7 @@ namespace qc {
         }
         // apply X operations to negate the respective controls again
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }
@@ -358,7 +360,7 @@ namespace qc {
 
     void StandardOperation::dumpOpenQASMSwap(std::ostream& of, const RegisterNames& qreg) const {
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }
@@ -370,7 +372,7 @@ namespace qc {
         of << " " << qreg[targets[0]].second << ", " << qreg[targets[1]].second << ";\n";
 
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }
@@ -379,7 +381,7 @@ namespace qc {
     void StandardOperation::dumpOpenQASMiSwap(std::ostream& of, const RegisterNames& qreg) const {
         const auto ctrlString = std::string(controls.size(), 'c');
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }
@@ -408,7 +410,7 @@ namespace qc {
         of << " " << qreg[targets[0]].second << ", " << qreg[targets[1]].second << ";\n";
 
         for (const auto& c: controls) {
-            if (c.type == dd::Control::Type::neg) {
+            if (c.type == Control::Type::Neg) {
                 of << "x " << qreg[c.qubit].second << ";\n";
             }
         }

--- a/src/operations/SymbolicOperation.cpp
+++ b/src/operations/SymbolicOperation.cpp
@@ -147,7 +147,7 @@ namespace qc {
         return Phase;
     }
 
-    void SymbolicOperation::checkUgate() {
+    void SymbolicOperation::checkSymbolicUgate() {
         if (type == Phase) {
             if (!isSymbolicParameter(0)) {
                 type = StandardOperation::parseU1(parameter[0]);
@@ -185,7 +185,7 @@ namespace qc {
         storeSymbolOrNumber(par1, 1);
         storeSymbolOrNumber(par2, 2);
         startQubit = startingQubit;
-        checkUgate();
+        checkSymbolicUgate();
         setName();
     }
 

--- a/src/operations/SymbolicOperation.cpp
+++ b/src/operations/SymbolicOperation.cpp
@@ -9,14 +9,14 @@ namespace qc {
 
     void SymbolicOperation::storeSymbolOrNumber(const SymbolOrNumber& param, std::size_t i) {
         if (std::holds_alternative<double>(param)) {
-            parameter[i] = std::get<double>(param);
+            parameter.at(i) = std::get<double>(param);
         } else {
-            symbolicParameter[i] = std::get<Symbolic>(param);
+            symbolicParameter.at(i) = std::get<Symbolic>(param);
         }
     }
 
-    OpType SymbolicOperation::parseU3(const Symbolic& lambda, dd::fp& phi,
-                                      dd::fp& theta) {
+    OpType SymbolicOperation::parseU3(const Symbolic& lambda, fp& phi,
+                                      fp& theta) {
         if (std::abs(theta) < PARAMETER_TOLERANCE &&
             std::abs(phi) < PARAMETER_TOLERANCE) {
             phi   = 0.L;
@@ -24,12 +24,9 @@ namespace qc {
             return SymbolicOperation::parseU1(lambda);
         }
 
-        if (std::abs(theta - dd::PI_2) < PARAMETER_TOLERANCE) {
-            theta    = dd::PI_2;
-            auto res = parseU2(lambda, phi);
-            if (res != U2)
-                theta = 0.L;
-            return res;
+        if (std::abs(theta - PI_2) < PARAMETER_TOLERANCE) {
+            theta = PI_2;
+            return parseU2(lambda, phi);
         }
         // parse a real u3 gate
         checkInteger(phi);
@@ -39,26 +36,23 @@ namespace qc {
 
         return U3;
     }
-    OpType SymbolicOperation::parseU3(dd::fp& lambda, const Symbolic& phi,
-                                      dd::fp& theta) {
-        if (std::abs(theta - dd::PI_2) < PARAMETER_TOLERANCE) {
-            theta    = dd::PI_2;
-            auto res = parseU2(lambda, phi);
-            if (res != U2)
-                theta = 0.L;
-            return res;
+    OpType SymbolicOperation::parseU3(fp& lambda, const Symbolic& phi,
+                                      fp& theta) {
+        if (std::abs(theta - PI_2) < PARAMETER_TOLERANCE) {
+            theta = PI_2;
+            return parseU2(lambda, phi);
         }
 
         if (std::abs(lambda) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
         }
 
-        if (std::abs(lambda - dd::PI_2) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI_2;
+        if (std::abs(lambda - PI_2) < PARAMETER_TOLERANCE) {
+            lambda = PI_2;
         }
 
-        if (std::abs(lambda - dd::PI) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI;
+        if (std::abs(lambda - PI) < PARAMETER_TOLERANCE) {
+            lambda = PI;
         }
 
         // parse a real u3 gate
@@ -69,7 +63,7 @@ namespace qc {
 
         return U3;
     }
-    OpType SymbolicOperation::parseU3(dd::fp& lambda, dd::fp& phi,
+    OpType SymbolicOperation::parseU3(fp& lambda, fp& phi,
                                       [[maybe_unused]] const Symbolic& theta) {
         if (std::abs(lambda) < PARAMETER_TOLERANCE) {
             lambda = 0.L;
@@ -78,16 +72,16 @@ namespace qc {
             }
         }
 
-        if (std::abs(lambda - dd::PI_2) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI_2;
+        if (std::abs(lambda - PI_2) < PARAMETER_TOLERANCE) {
+            lambda = PI_2;
 
-            if (std::abs(phi - dd::PI_2) < PARAMETER_TOLERANCE) {
-                phi = dd::PI_2;
+            if (std::abs(phi - PI_2) < PARAMETER_TOLERANCE) {
+                phi = PI_2;
             }
         }
 
-        if (std::abs(lambda - dd::PI) < PARAMETER_TOLERANCE) {
-            lambda = dd::PI;
+        if (std::abs(lambda - PI) < PARAMETER_TOLERANCE) {
+            lambda = PI;
             if (std::abs(phi) < PARAMETER_TOLERANCE) {
                 phi = 0.L;
             }
@@ -102,13 +96,10 @@ namespace qc {
         return U3;
     }
     OpType SymbolicOperation::parseU3(const Symbolic& lambda,
-                                      const Symbolic& phi, dd::fp& theta) {
-        if (std::abs(theta - dd::PI_2) < PARAMETER_TOLERANCE) {
-            theta    = dd::PI_2;
-            auto res = parseU2(lambda, phi);
-            if (res != U2)
-                theta = 0.L;
-            return res;
+                                      const Symbolic& phi, fp& theta) {
+        if (std::abs(theta - PI_2) < PARAMETER_TOLERANCE) {
+            theta = PI_2;
+            return parseU2(lambda, phi);
         }
 
         // parse a real u3 gate
@@ -118,7 +109,7 @@ namespace qc {
 
         return U3;
     }
-    OpType SymbolicOperation::parseU3([[maybe_unused]] const Symbolic& lambda, dd::fp& phi,
+    OpType SymbolicOperation::parseU3([[maybe_unused]] const Symbolic& lambda, fp& phi,
                                       [[maybe_unused]] const Symbolic& theta) {
         // parse a real u3 gate
         checkInteger(phi);
@@ -126,7 +117,7 @@ namespace qc {
 
         return U3;
     }
-    OpType SymbolicOperation::parseU3(dd::fp& lambda, [[maybe_unused]] const Symbolic& phi,
+    OpType SymbolicOperation::parseU3(fp& lambda, [[maybe_unused]] const Symbolic& phi,
                                       [[maybe_unused]] const Symbolic& theta) {
         // parse a real u3 gate
         checkInteger(lambda);
@@ -139,13 +130,13 @@ namespace qc {
         return U2;
     }
 
-    OpType SymbolicOperation::parseU2([[maybe_unused]] const Symbolic& lambda, dd::fp& phi) {
+    OpType SymbolicOperation::parseU2([[maybe_unused]] const Symbolic& lambda, fp& phi) {
         checkInteger(phi);
         checkFractionPi(phi);
 
         return U2;
     }
-    OpType SymbolicOperation::parseU2(dd::fp& lambda, [[maybe_unused]] const Symbolic& phi) {
+    OpType SymbolicOperation::parseU2(fp& lambda, [[maybe_unused]] const Symbolic& phi) {
         checkInteger(lambda);
         checkFractionPi(lambda);
 
@@ -158,34 +149,37 @@ namespace qc {
 
     void SymbolicOperation::checkUgate() {
         if (type == Phase) {
-            if (!isSymbolicParameter(0))
+            if (!isSymbolicParameter(0)) {
                 type = StandardOperation::parseU1(parameter[0]);
+            }
         } else if (type == U2) {
-            if (!isSymbolicParameter(0) && !isSymbolicParameter(1))
+            if (!isSymbolicParameter(0) && !isSymbolicParameter(1)) {
                 type = StandardOperation::parseU2(parameter[0], parameter[1]);
-            else if (isSymbolicParameter(0))
+            } else if (isSymbolicParameter(0)) {
                 type = parseU2(symbolicParameter[0].value(), parameter[1]);
-            else if (isSymbolicParameter(1))
+            } else if (isSymbolicParameter(1)) {
                 type = parseU2(parameter[1], symbolicParameter[1].value());
+            }
         } else if (type == U3) {
-            if (!isSymbolicParameter(0) && !isSymbolicParameter(1) && !isSymbolicParameter(2))
+            if (!isSymbolicParameter(0) && !isSymbolicParameter(1) && !isSymbolicParameter(2)) {
                 type = StandardOperation::parseU3(parameter[0], parameter[1], parameter[2]);
-            else if (!isSymbolicParameter(0) && !isSymbolicParameter(1))
+            } else if (!isSymbolicParameter(0) && !isSymbolicParameter(1)) {
                 type = parseU3(parameter[0], parameter[1], symbolicParameter[2].value());
-            else if (!isSymbolicParameter(0) && !isSymbolicParameter(2))
+            } else if (!isSymbolicParameter(0) && !isSymbolicParameter(2)) {
                 type = parseU3(parameter[0], symbolicParameter[1].value(), parameter[2]);
-            else if (!isSymbolicParameter(1) && !isSymbolicParameter(2))
+            } else if (!isSymbolicParameter(1) && !isSymbolicParameter(2)) {
                 type = parseU3(symbolicParameter[0].value(), parameter[1], parameter[2]);
-            else if (!isSymbolicParameter(0))
+            } else if (!isSymbolicParameter(0)) {
                 type = parseU3(parameter[0], symbolicParameter[1].value(), symbolicParameter[2].value());
-            else if (!isSymbolicParameter(1))
+            } else if (!isSymbolicParameter(1)) {
                 type = parseU3(symbolicParameter[0].value(), parameter[1], symbolicParameter[2].value());
-            else if (!isSymbolicParameter(2))
+            } else if (!isSymbolicParameter(2)) {
                 type = parseU3(symbolicParameter[0].value(), symbolicParameter[1].value(), parameter[2]);
+            }
         }
     }
 
-    void SymbolicOperation::setup(dd::QubitCount nq, const SymbolOrNumber& par0, const SymbolOrNumber& par1, const SymbolOrNumber& par2, dd::Qubit startingQubit) {
+    void SymbolicOperation::setup(const std::size_t nq, const SymbolOrNumber& par0, const SymbolOrNumber& par1, const SymbolOrNumber& par2, const Qubit startingQubit) {
         nqubits = nq;
         storeSymbolOrNumber(par0, 0);
         storeSymbolOrNumber(par1, 1);
@@ -195,47 +189,47 @@ namespace qc {
         setName();
     }
 
-    [[nodiscard]] dd::fp SymbolicOperation::getInstantiation(const SymbolOrNumber& symOrNum, const VariableAssignment& assignment) {
+    [[nodiscard]] fp SymbolicOperation::getInstantiation(const SymbolOrNumber& symOrNum, const VariableAssignment& assignment) {
         return std::visit(Overload{
-                                  [&](const dd::fp num) { return num; },
+                                  [&](const fp num) { return num; },
                                   [&](const Symbolic& sym) { return sym.evaluate(assignment); }},
                           symOrNum);
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, dd::Qubit target, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit) {
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Qubit target, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit) {
         type = g;
         setup(nq, lambda, phi, theta, startingQubit);
         targets.emplace_back(target);
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, const Targets& targets, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit) {
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Targets& targets, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit) {
         type = g;
         setup(nq, lambda, phi, theta, startingQubit);
         this->targets = targets;
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, dd::Control control, dd::Qubit target, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit):
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Control control, const Qubit target, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit):
         SymbolicOperation(nq, target, g, lambda, phi, theta, startingQubit) {
         controls.insert(control);
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, dd::Control control, const Targets& targets, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit):
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Control control, const Targets& targets, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit):
         SymbolicOperation(nq, targets, g, lambda, phi, theta, startingQubit) {
         controls.insert(control);
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit):
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Controls& controls, const Qubit target, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit):
         SymbolicOperation(nq, target, g, lambda, phi, theta, startingQubit) {
         this->controls = controls;
     }
 
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, const Targets& targets, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit):
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Controls& controls, const Targets& targets, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit):
         SymbolicOperation(nq, targets, g, lambda, phi, theta, startingQubit) {
         this->controls = controls;
     }
 
     // MCF (cSWAP), Peres, paramterized two target Constructor
-    SymbolicOperation::SymbolicOperation(dd::QubitCount nq, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, dd::Qubit startingQubit):
+    SymbolicOperation::SymbolicOperation(const std::size_t nq, const Controls& controls, const Qubit target0, const Qubit target1, const OpType g, const SymbolOrNumber& lambda, const SymbolOrNumber& phi, const SymbolOrNumber& theta, const Qubit startingQubit):
         SymbolicOperation(nq, controls, {target0, target1}, g, lambda, phi, theta, startingQubit) {
     }
 
@@ -243,16 +237,22 @@ namespace qc {
         if (!op.isSymbolicOperation() && !isStandardOperation()) {
             return false;
         }
-        if (isStandardOperation() && qc::StandardOperation::equals(op, perm1, perm2)) return true;
+        if (isStandardOperation() && qc::StandardOperation::equals(op, perm1, perm2)) {
+            return true;
+        }
 
-        if (!op.isSymbolicOperation()) return false;
+        if (!op.isSymbolicOperation()) {
+            return false;
+        }
         const auto& symOp = dynamic_cast<const SymbolicOperation&>(op);
         for (std::size_t i = 0; i < symbolicParameter.size(); ++i) {
-            if (symbolicParameter[i].has_value() != symOp.symbolicParameter[i].has_value())
+            if (symbolicParameter.at(i).has_value() != symOp.symbolicParameter.at(i).has_value()) {
                 return false;
+            }
 
-            if (symbolicParameter[i].has_value())
-                return symbolicParameter[i].value() == symOp.symbolicParameter[i].value();
+            if (symbolicParameter.at(i).has_value()) {
+                return symbolicParameter.at(i).value() == symOp.symbolicParameter.at(i).value();
+            }
         }
         return true;
     }
@@ -265,15 +265,15 @@ namespace qc {
         auto lambda = getInstantiation(getParameter(0), assignment);
         auto phi    = getInstantiation(getParameter(1), assignment);
         auto theta  = getInstantiation(getParameter(2), assignment);
-        return StandardOperation(nqubits, targets, type, lambda, phi, theta, startQubit);
+        return {nqubits, targets, type, lambda, phi, theta, startQubit};
     }
 
     // Instantiates this Operation
     // Afterwards casting to StandardOperation can be done if assignment is total
     void SymbolicOperation::instantiate(const VariableAssignment& assignment) {
         for (std::size_t i = 0; i < symbolicParameter.size(); ++i) {
-            parameter[i] = getInstantiation(getParameter(i), assignment);
-            symbolicParameter[i].reset();
+            parameter.at(i) = getInstantiation(getParameter(i), assignment);
+            symbolicParameter.at(i).reset();
         }
         checkUgate();
     }

--- a/src/parsers/GRCSParser.cpp
+++ b/src/parsers/GRCSParser.cpp
@@ -17,29 +17,31 @@ void qc::QuantumComputation::importGRCS(std::istream& is) {
     std::size_t target  = 0;
     std::size_t cycle   = 0;
     while (std::getline(is, line)) {
-        if (line.empty()) continue;
+        if (line.empty()) {
+            continue;
+        }
         std::stringstream ss(line);
         ss >> cycle;
         ss >> identifier;
         if (identifier == "cz") {
             ss >> control;
             ss >> target;
-            emplace_back<StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(control)}, target, Z);
+            z(target, qc::Control{static_cast<qc::Qubit>(control)});
         } else if (identifier == "is") {
             ss >> control;
             ss >> target;
-            emplace_back<StandardOperation>(nqubits, dd::Controls{}, control, target, iSWAP);
+            iswap(control, target);
         } else {
             ss >> target;
-            if (identifier == "h")
-                emplace_back<StandardOperation>(nqubits, target, H);
-            else if (identifier == "t")
-                emplace_back<StandardOperation>(nqubits, target, T);
-            else if (identifier == "x_1_2")
-                emplace_back<StandardOperation>(nqubits, target, RX, dd::PI_2);
-            else if (identifier == "y_1_2")
-                emplace_back<StandardOperation>(nqubits, target, RY, dd::PI_2);
-            else {
+            if (identifier == "h") {
+                h(target);
+            } else if (identifier == "t") {
+                t(target);
+            } else if (identifier == "x_1_2") {
+                rx(target, qc::PI_2);
+            } else if (identifier == "y_1_2") {
+                ry(target, qc::PI_2);
+            } else {
                 throw QFRException("[grcs parser] unknown gate '" + identifier + "'");
             }
         }

--- a/src/parsers/QASMParser.cpp
+++ b/src/parsers/QASMParser.cpp
@@ -20,10 +20,10 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
             // quantum register definition
             p.scan();
             p.check(Token::Kind::identifier);
-            std::string s = p.t.str;
+            const std::string s = p.t.str;
             p.check(Token::Kind::lbrack);
             p.check(Token::Kind::nninteger);
-            auto n = static_cast<dd::QubitCount>(p.t.val);
+            const auto n = static_cast<std::size_t>(p.t.val);
             p.check(Token::Kind::rbrack);
             p.check(Token::Kind::semicolon);
             addQubitRegister(n, s.c_str());
@@ -32,10 +32,10 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
             // classical register definition
             p.scan();
             p.check(Token::Kind::identifier);
-            std::string s = p.t.str;
+            const std::string s = p.t.str;
             p.check(Token::Kind::lbrack);
             p.check(Token::Kind::nninteger);
-            auto n = static_cast<std::size_t>(p.t.val);
+            const auto n = static_cast<std::size_t>(p.t.val);
             p.check(Token::Kind::rbrack);
             p.check(Token::Kind::semicolon);
             addClassicalRegister(n, s.c_str());
@@ -59,10 +59,10 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
             p.ArgList(args);
             p.check(Token::Kind::semicolon);
 
-            std::vector<dd::Qubit> qubits{};
+            std::vector<qc::Qubit> qubits{};
             for (auto& arg: args) {
-                for (dd::QubitCount q = 0; q < arg.second; ++q) {
-                    qubits.emplace_back(static_cast<dd::Qubit>(arg.first + q));
+                for (std::size_t q = 0; q < arg.second; ++q) {
+                    qubits.emplace_back(arg.first + q);
                 }
             }
 
@@ -75,10 +75,10 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
             p.scan();
             p.check(Token::Kind::lpar);
             p.check(Token::Kind::identifier);
-            std::string creg = p.t.str;
+            const std::string creg = p.t.str;
             p.check(Token::Kind::eq);
             p.check(Token::Kind::nninteger);
-            auto n = static_cast<dd::QubitCount>(p.t.val);
+            const auto n = static_cast<std::size_t>(p.t.val);
             p.check(Token::Kind::rpar);
 
             auto it = p.cregs.find(creg);

--- a/src/parsers/qasm_parser/Parser.cpp
+++ b/src/parsers/qasm_parser/Parser.cpp
@@ -15,31 +15,37 @@ namespace qasm {
         if (sym == Token::Kind::minus) {
             scan();
             x = Exponentiation();
-            if (x->kind == Expr::Kind::number)
+            if (x->kind == Expr::Kind::number) {
                 x->num = -x->num;
-            else
+            } else {
                 x = new Expr(Expr::Kind::sign, 0., x);
+            }
             return x;
         }
 
         if (sym == Token::Kind::real) {
             scan();
             return new Expr(Expr::Kind::number, t.valReal);
-        } else if (sym == Token::Kind::nninteger) {
+        }
+        if (sym == Token::Kind::nninteger) {
             scan();
             return new Expr(Expr::Kind::number, t.val);
-        } else if (sym == Token::Kind::pi) {
+        }
+        if (sym == Token::Kind::pi) {
             scan();
-            return new Expr(Expr::Kind::number, dd::PI);
-        } else if (sym == Token::Kind::identifier) {
+            return new Expr(Expr::Kind::number, qc::PI);
+        }
+        if (sym == Token::Kind::identifier) {
             scan();
             return new Expr(Expr::Kind::id, 0., nullptr, nullptr, t.str);
-        } else if (sym == Token::Kind::lpar) {
+        }
+        if (sym == Token::Kind::lpar) {
             scan();
             x = Exp();
             check(Token::Kind::rpar);
             return x;
-        } else if (unaryops.find(sym) != unaryops.end()) {
+        }
+        if (unaryops.find(sym) != unaryops.end()) {
             auto op = sym;
             scan();
             check(Token::Kind::lpar);
@@ -60,20 +66,24 @@ namespace qasm {
                     x->num = std::sqrt(x->num);
                 }
                 return x;
-            } else {
-                if (op == Token::Kind::sin) {
-                    return new Expr(Expr::Kind::sin, 0., x);
-                } else if (op == Token::Kind::cos) {
-                    return new Expr(Expr::Kind::cos, 0., x);
-                } else if (op == Token::Kind::tan) {
-                    return new Expr(Expr::Kind::tan, 0., x);
-                } else if (op == Token::Kind::exp) {
-                    return new Expr(Expr::Kind::exp, 0., x);
-                } else if (op == Token::Kind::ln) {
-                    return new Expr(Expr::Kind::ln, 0., x);
-                } else if (op == Token::Kind::sqrt) {
-                    return new Expr(Expr::Kind::sqrt, 0., x);
-                }
+            }
+            if (op == Token::Kind::sin) {
+                return new Expr(Expr::Kind::sin, 0., x);
+            }
+            if (op == Token::Kind::cos) {
+                return new Expr(Expr::Kind::cos, 0., x);
+            }
+            if (op == Token::Kind::tan) {
+                return new Expr(Expr::Kind::tan, 0., x);
+            }
+            if (op == Token::Kind::exp) {
+                return new Expr(Expr::Kind::exp, 0., x);
+            }
+            if (op == Token::Kind::ln) {
+                return new Expr(Expr::Kind::ln, 0., x);
+            }
+            if (op == Token::Kind::sqrt) {
+                return new Expr(Expr::Kind::sqrt, 0., x);
             }
         } else {
             error("Invalid Expression");
@@ -132,10 +142,11 @@ namespace qasm {
         if (sym == Token::Kind::minus) {
             scan();
             x = Term();
-            if (x->kind == Expr::Kind::number)
+            if (x->kind == Expr::Kind::number) {
                 x->num = -x->num;
-            else
+            } else {
                 x = new Expr(Expr::Kind::sign, 0., x);
+            }
         } else {
             x = Term();
         }
@@ -145,28 +156,33 @@ namespace qasm {
             scan();
             y = Term();
             if (op == Token::Kind::plus) {
-                if (x->kind == Expr::Kind::number && y->kind == Expr::Kind::number)
+                if (x->kind == Expr::Kind::number && y->kind == Expr::Kind::number) {
                     x->num += y->num;
-                else
+                } else {
                     x = new Expr(Expr::Kind::plus, 0., x, y);
+                }
             } else {
-                if (x->kind == Expr::Kind::number && y->kind == Expr::Kind::number)
+                if (x->kind == Expr::Kind::number && y->kind == Expr::Kind::number) {
                     x->num -= y->num;
-                else
+                } else {
                     x = new Expr(Expr::Kind::minus, 0., x, y);
+                }
             }
         }
         return x;
     }
 
     Parser::Expr* Parser::RewriteExpr(Expr* expr, std::map<std::string, Expr*>& exprMap) {
-        if (expr == nullptr) return nullptr;
+        if (expr == nullptr) {
+            return nullptr;
+        }
         Expr* op1 = RewriteExpr(expr->op1, exprMap);
         Expr* op2 = RewriteExpr(expr->op2, exprMap);
 
         if (expr->kind == Expr::Kind::number) {
             return new Expr(expr->kind, expr->num, op1, op2, expr->id);
-        } else if (expr->kind == Expr::Kind::plus) {
+        }
+        if (expr->kind == Expr::Kind::plus) {
             if (op1->kind == Expr::Kind::number && op2->kind == Expr::Kind::number) {
                 op1->num = op1->num + op2->num;
                 delete op2;
@@ -263,11 +279,11 @@ namespace qasm {
         static auto     qubitRegex         = std::regex("\\d+");
         qc::Permutation initial{};
         if (std::regex_search(comment, initialLayoutRegex)) {
-            dd::Qubit logical_qubit = 0;
+            qc::Qubit logicalQubit = 0;
             for (std::smatch m; std::regex_search(comment, m, qubitRegex); comment = m.suffix()) {
-                auto physical_qubit = static_cast<dd::Qubit>(std::stoul(m.str()));
-                initial.insert({physical_qubit, logical_qubit});
-                ++logical_qubit;
+                auto physicalQubit = static_cast<qc::Qubit>(std::stoul(m.str()));
+                initial.insert({physicalQubit, logicalQubit});
+                ++logicalQubit;
             }
         }
         return initial;
@@ -278,11 +294,11 @@ namespace qasm {
         static auto     qubitRegex             = std::regex("\\d+");
         qc::Permutation output{};
         if (std::regex_search(comment, outputPermutationRegex)) {
-            dd::Qubit logical_qubit = 0;
+            qc::Qubit logicalQubit = 0;
             for (std::smatch m; std::regex_search(comment, m, qubitRegex); comment = m.suffix()) {
-                auto physical_qubit = static_cast<dd::Qubit>(std::stoul(m.str()));
-                output.insert({physical_qubit, logical_qubit});
-                ++logical_qubit;
+                auto physicalQubit = static_cast<qc::Qubit>(std::stoul(m.str()));
+                output.insert({physicalQubit, logicalQubit});
+                ++logicalQubit;
             }
         }
         return output;
@@ -312,14 +328,15 @@ namespace qasm {
 
     qc::QuantumRegister Parser::ArgumentQreg() {
         check(Token::Kind::identifier);
-        std::string s = t.str;
-        if (qregs.find(s) == qregs.end())
+        const std::string s = t.str;
+        if (qregs.find(s) == qregs.end()) {
             error("Argument is not a qreg: " + s);
+        }
 
         if (sym == Token::Kind::lbrack) {
             scan();
             check(Token::Kind::nninteger);
-            auto offset = static_cast<dd::QubitCount>(t.val);
+            auto offset = static_cast<std::size_t>(t.val);
             check(Token::Kind::rbrack);
             return std::make_pair(qregs[s].first + offset, 1);
         }
@@ -328,9 +345,10 @@ namespace qasm {
 
     qc::ClassicalRegister Parser::ArgumentCreg() {
         check(Token::Kind::identifier);
-        std::string s = t.str;
-        if (cregs.find(s) == cregs.end())
+        const std::string s = t.str;
+        if (cregs.find(s) == cregs.end()) {
             error("Argument is not a creg: " + s);
+        }
 
         if (sym == Token::Kind::lbrack) {
             scan();
@@ -388,11 +406,12 @@ namespace qasm {
 
             // TODO: multiple targets could be useful here
             auto gate = qc::CompoundOperation(nqubits);
-            for (dd::QubitCount i = 0; i < target.second; ++i) {
-                gate.emplace_back<qc::StandardOperation>(nqubits, static_cast<dd::Qubit>(target.first + i), qc::U3, lambda->num, phi->num, theta->num);
+            for (std::size_t i = 0; i < target.second; ++i) {
+                gate.emplace_back<qc::StandardOperation>(nqubits, target.first + i, qc::U3, lambda->num, phi->num, theta->num);
             }
             return std::make_unique<qc::CompoundOperation>(std::move(gate));
-        } else if (sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain) {
+        }
+        if (sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain) {
             auto type = sym;
             scan();
             std::vector<qc::QuantumRegister> registers{};
@@ -403,7 +422,7 @@ namespace qasm {
             }
             scan();
 
-            std::vector<dd::Control> qubits{};
+            std::vector<qc::Control> qubits{};
             for (const auto& reg: registers) {
                 if (reg.second != 1) {
                     error("MCX for whole qubit registers not yet implemented");
@@ -415,15 +434,16 @@ namespace qasm {
                     error(oss.str());
                 }
 
-                qubits.emplace_back(dd::Control{reg.first});
+                qubits.emplace_back(qc::Control{reg.first});
             }
 
             // drop ancillaries since our library can natively work with MCTs
             if (type == Token::Kind::mcx_vchain) {
                 // n controls, 1 target, n-2 ancillaries = 2n-1 qubits
-                dd::QubitCount ancillaries = (qubits.size() + 1) / 2 - 2;
-                for (int i = 0; i < ancillaries; ++i)
+                const auto ancillaries = (qubits.size() + 1) / 2 - 2;
+                for (std::size_t i = 0; i < ancillaries; ++i) {
                     qubits.pop_back();
+                }
             } else if (type == Token::Kind::mcx_recursive) {
                 // 1 ancillary if more than 4 controls
                 if (qubits.size() > 5) {
@@ -432,11 +452,12 @@ namespace qasm {
             }
             auto target = qubits.back().qubit;
             qubits.pop_back();
-            return std::make_unique<qc::StandardOperation>(nqubits, dd::Controls{qubits.cbegin(), qubits.cend()}, target);
-        } else if (sym == Token::Kind::mcphase) {
+            return std::make_unique<qc::StandardOperation>(nqubits, qc::Controls{qubits.cbegin(), qubits.cend()}, target);
+        }
+        if (sym == Token::Kind::mcphase) {
             scan();
             check(Token::Kind::lpar);
-            std::unique_ptr<Expr> lambda(Exp());
+            const std::unique_ptr<Expr> lambda(Exp());
             check(Token::Kind::rpar);
 
             std::vector<qc::QuantumRegister> registers{};
@@ -447,7 +468,7 @@ namespace qasm {
             }
             scan();
 
-            std::vector<dd::Control> qubits{};
+            std::vector<qc::Control> qubits{};
             for (const auto& reg: registers) {
                 if (reg.second != 1) {
                     error("MCPhase for whole qubit registers not yet implemented");
@@ -459,28 +480,29 @@ namespace qasm {
                     error(oss.str());
                 }
 
-                qubits.emplace_back(dd::Control{reg.first});
+                qubits.emplace_back(qc::Control{reg.first});
             }
             auto target = qubits.back().qubit;
             qubits.pop_back();
-            return std::make_unique<qc::StandardOperation>(nqubits, dd::Controls{qubits.cbegin(), qubits.cend()}, target, qc::Phase, lambda->num);
-        } else if (sym == Token::Kind::swap) {
+            return std::make_unique<qc::StandardOperation>(nqubits, qc::Controls{qubits.cbegin(), qubits.cend()}, target, qc::Phase, lambda->num);
+        }
+        if (sym == Token::Kind::swap) {
             scan();
-            auto first_target = ArgumentQreg();
+            auto firstTarget = ArgumentQreg();
             check(Token::Kind::comma);
-            auto second_target = ArgumentQreg();
+            auto secondTarget = ArgumentQreg();
             check(Token::Kind::semicolon);
 
             // return corresponding operation
-            if (first_target.second == 1 && second_target.second == 1) {
-                if (first_target.first == second_target.first) {
+            if (firstTarget.second == 1 && secondTarget.second == 1) {
+                if (firstTarget.first == secondTarget.first) {
                     error("SWAP with two identical targets");
                 }
-                return std::make_unique<qc::StandardOperation>(nqubits, dd::Controls{}, first_target.first, second_target.first, qc::SWAP);
-            } else {
-                error("SWAP for whole qubit registers not yet implemented");
+                return std::make_unique<qc::StandardOperation>(nqubits, qc::Controls{}, firstTarget.first, secondTarget.first, qc::SWAP);
             }
-        } else if (sym == Token::Kind::cxgate) {
+            error("SWAP for whole qubit registers not yet implemented");
+        }
+        if (sym == Token::Kind::cxgate) {
             scan();
             auto control = ArgumentQreg();
             check(Token::Kind::comma);
@@ -488,8 +510,8 @@ namespace qasm {
             check(Token::Kind::semicolon);
 
             // valid check
-            for (int i = 0; i < control.second; ++i) {
-                for (int j = 0; j < target.second; ++j) {
+            for (std::size_t i = 0; i < control.second; ++i) {
+                for (std::size_t j = 0; j < target.second; ++j) {
                     if (control.first + i == target.first + j) {
                         std::ostringstream oss{};
                         oss << "Qubit " << control.first + i << " cannot be control and target at the same time";
@@ -500,26 +522,28 @@ namespace qasm {
 
             // return corresponding operation
             if (control.second == 1 && target.second == 1) {
-                return std::make_unique<qc::StandardOperation>(nqubits, dd::Control{control.first}, target.first, qc::X);
-            } else {
-                auto gate = qc::CompoundOperation(nqubits);
-                if (control.second == target.second) {
-                    for (dd::QubitCount i = 0; i < target.second; ++i)
-                        gate.emplace_back<qc::StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(control.first + i)}, target.first + i, qc::X);
-                } else if (control.second == 1) {
-                    // TODO: multiple targets could be useful here
-                    for (dd::QubitCount i = 0; i < target.second; ++i)
-                        gate.emplace_back<qc::StandardOperation>(nqubits, dd::Control{control.first}, target.first + i, qc::X);
-                } else if (target.second == 1) {
-                    for (dd::QubitCount i = 0; i < control.second; ++i)
-                        gate.emplace_back<qc::StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(control.first + i)}, target.first, qc::X);
-                } else {
-                    error("Register size does not match for CX gate!");
-                }
-                return std::make_unique<qc::CompoundOperation>(std::move(gate));
+                return std::make_unique<qc::StandardOperation>(nqubits, qc::Control{control.first}, target.first, qc::X);
             }
-
-        } else if (sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
+            auto gate = qc::CompoundOperation(nqubits);
+            if (control.second == target.second) {
+                for (std::size_t i = 0; i < target.second; ++i) {
+                    gate.emplace_back<qc::StandardOperation>(nqubits, qc::Control{static_cast<qc::Qubit>(control.first + i)}, target.first + i, qc::X);
+                }
+            } else if (control.second == 1) {
+                // TODO: multiple targets could be useful here
+                for (std::size_t i = 0; i < target.second; ++i) {
+                    gate.emplace_back<qc::StandardOperation>(nqubits, qc::Control{control.first}, target.first + i, qc::X);
+                }
+            } else if (target.second == 1) {
+                for (std::size_t i = 0; i < control.second; ++i) {
+                    gate.emplace_back<qc::StandardOperation>(nqubits, qc::Control{static_cast<qc::Qubit>(control.first + i)}, target.first, qc::X);
+                }
+            } else {
+                error("Register size does not match for CX gate!");
+            }
+            return std::make_unique<qc::CompoundOperation>(std::move(gate));
+        }
+        if (sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
             const auto type = (sym == Token::Kind::sxgate) ? qc::SX : qc::SXdag;
             scan();
 
@@ -532,15 +556,16 @@ namespace qasm {
 
             // TODO: multiple targets could be useful here
             auto gate = qc::CompoundOperation(nqubits);
-            for (dd::QubitCount i = 0; i < target.second; ++i) {
-                gate.emplace_back<qc::StandardOperation>(nqubits, static_cast<dd::Qubit>(target.first + i), type);
+            for (std::size_t i = 0; i < target.second; ++i) {
+                gate.emplace_back<qc::StandardOperation>(nqubits, target.first + i, type);
             }
             return std::make_unique<qc::CompoundOperation>(std::move(gate));
-        } else if (sym == Token::Kind::identifier) {
+        }
+        if (sym == Token::Kind::identifier) {
             scan();
-            auto           gateName  = t.str;
-            auto           cGateName = gateName;
-            dd::QubitCount ncontrols = 0;
+            auto        gateName  = t.str;
+            auto        cGateName = gateName;
+            std::size_t ncontrols = 0;
             while (cGateName.front() == 'c') {
                 cGateName = cGateName.substr(1);
                 ncontrols++;
@@ -568,18 +593,19 @@ namespace qasm {
 
                 for (size_t i = 0; i < arguments.size(); ++i) {
                     argMap["q" + std::to_string(i)] = arguments[i];
-                    if (arguments[i].second > 1)
+                    if (arguments[i].second > 1) {
                         error("cSWAP with whole qubit registers not yet implemented");
+                    }
                 }
 
-                dd::Controls controls{};
-                for (dd::QubitCount j = 0; j < ncontrols; ++j) {
-                    auto arg = "q" + std::to_string(j);
-                    controls.emplace(dd::Control{argMap.at(arg).first});
+                qc::Controls controls{};
+                for (std::size_t j = 0; j < ncontrols; ++j) {
+                    const auto arg = "q" + std::to_string(j);
+                    controls.emplace(qc::Control{argMap.at(arg).first});
                 }
 
-                auto targ  = "q" + std::to_string(ncontrols);
-                auto targ2 = "q" + std::to_string(ncontrols + 1);
+                const auto targ  = "q" + std::to_string(ncontrols);
+                const auto targ2 = "q" + std::to_string(ncontrols + 1);
                 return std::make_unique<qc::StandardOperation>(nqubits, controls,
                                                                argMap.at(targ).first,
                                                                argMap.at(targ2).first,
@@ -593,8 +619,9 @@ namespace qasm {
                 std::vector<qc::QuantumRegister> arguments;
                 if (sym == Token::Kind::lpar) {
                     scan();
-                    if (sym != Token::Kind::rpar)
+                    if (sym != Token::Kind::rpar) {
                         ExpList(parameters);
+                    }
                     check(Token::Kind::rpar);
                 }
                 ArgList(arguments);
@@ -603,7 +630,7 @@ namespace qasm {
                 // return corresponding operation
                 qc::QuantumRegisterMap       argMap;
                 std::map<std::string, Expr*> paramMap;
-                dd::QubitCount               size = 1;
+                std::size_t                  size = 1;
                 if (gateIt != compoundGates.end()) {
                     if ((*gateIt).second.argumentNames.size() != arguments.size()) {
                         std::ostringstream oss{};
@@ -618,15 +645,18 @@ namespace qasm {
 
                     for (size_t i = 0; i < arguments.size(); ++i) {
                         argMap[gateIt->second.argumentNames[i]] = arguments[i];
-                        if (arguments[i].second > 1 && size != 1 && arguments[i].second != size)
+                        if (arguments[i].second > 1 && size != 1 && arguments[i].second != size) {
                             error("Register sizes do not match!");
+                        }
 
-                        if (arguments[i].second > 1)
+                        if (arguments[i].second > 1) {
                             size = arguments[i].second;
+                        }
                     }
 
-                    for (size_t i = 0; i < parameters.size(); ++i)
+                    for (size_t i = 0; i < parameters.size(); ++i) {
                         paramMap[gateIt->second.parameterNames[i]] = parameters[i];
+                    }
                 } else { // controlled Gate treatment
                     if (cGateIt->second.gates.size() > 1) {
                         std::ostringstream oss{};
@@ -653,25 +683,28 @@ namespace qasm {
 
                     for (size_t i = 0; i < arguments.size(); ++i) {
                         argMap["q" + std::to_string(i)] = arguments[i];
-                        if (arguments[i].second > 1 && size != 1 && arguments[i].second != size)
+                        if (arguments[i].second > 1 && size != 1 && arguments[i].second != size) {
                             error("Register sizes do not match!");
+                        }
 
-                        if (arguments[i].second > 1)
+                        if (arguments[i].second > 1) {
                             size = arguments[i].second;
+                        }
                     }
 
-                    for (size_t i = 0; i < parameters.size(); ++i)
+                    for (size_t i = 0; i < parameters.size(); ++i) {
                         paramMap[cGateIt->second.parameterNames[i]] = parameters[i];
+                    }
                 }
 
                 // check if single controlled gate
                 if (ncontrols > 0 && size == 1) {
                     // TODO: this could be enhanced for the case that any argument is a register
                     if (cGateIt->second.gates.size() == 1) {
-                        dd::Controls controls{};
-                        for (dd::QubitCount j = 0; j < ncontrols; ++j) {
+                        qc::Controls controls{};
+                        for (std::size_t j = 0; j < ncontrols; ++j) {
                             auto arg = (gateIt != compoundGates.end()) ? gateIt->second.argumentNames[j] : ("q" + std::to_string(j));
-                            controls.emplace(dd::Control{argMap.at(arg).first});
+                            controls.emplace(qc::Control{argMap.at(arg).first});
                         }
 
                         auto targ = (gateIt != compoundGates.end()) ? gateIt->second.argumentNames.back() : ("q" + std::to_string(ncontrols));
@@ -681,28 +714,29 @@ namespace qasm {
                             return std::make_unique<qc::StandardOperation>(nqubits, controls, argMap.at(targ).first);
                         }
 
-                        auto cGate = cGateIt->second.gates.front();
-                        for (size_t j = 0; j < parameters.size(); ++j)
+                        const auto cGate = cGateIt->second.gates.front();
+                        for (size_t j = 0; j < parameters.size(); ++j) {
                             paramMap[cGateIt->second.parameterNames[j]] = parameters[j];
+                        }
 
-                        if (auto cu = dynamic_cast<SingleQubitGate*>(cGate)) {
+                        if (auto* cu = dynamic_cast<SingleQubitGate*>(cGate)) {
                             std::unique_ptr<Expr> theta(RewriteExpr(cu->theta, paramMap));
                             std::unique_ptr<Expr> phi(RewriteExpr(cu->phi, paramMap));
                             std::unique_ptr<Expr> lambda(RewriteExpr(cu->lambda, paramMap));
 
                             return std::make_unique<qc::StandardOperation>(nqubits, controls, argMap.at(targ).first, qc::U3, lambda->num, phi->num, theta->num);
-                        } else {
-                            error("Cast to u-Gate not possible for controlled operation.");
                         }
+                        error("Cast to u-Gate not possible for controlled operation.");
                     }
-                } else if (gateIt == compoundGates.end()) {
+                }
+                if (gateIt == compoundGates.end()) {
                     error("Controlled operation for which no definition could be found or which acts on whole qubit register.");
                 }
 
                 // identifier specifies just a single operation (U3 or CX)
                 if (gateIt != compoundGates.end() && gateIt->second.gates.size() == 1) {
-                    auto gate = gateIt->second.gates.front();
-                    if (auto u = dynamic_cast<SingleQubitGate*>(gate)) {
+                    const auto gate = gateIt->second.gates.front();
+                    if (auto* u = dynamic_cast<SingleQubitGate*>(gate)) {
                         std::unique_ptr<Expr> theta(RewriteExpr(u->theta, paramMap));
                         std::unique_ptr<Expr> phi(RewriteExpr(u->phi, paramMap));
                         std::unique_ptr<Expr> lambda(RewriteExpr(u->lambda, paramMap));
@@ -710,16 +744,16 @@ namespace qasm {
                         if (argMap.at(u->target).second == 1) {
                             return std::make_unique<qc::StandardOperation>(nqubits, argMap.at(u->target).first, qc::U3, lambda->num, phi->num, theta->num);
                         }
-                    } else if (auto cx = dynamic_cast<CXgate*>(gate)) {
+                    } else if (auto* cx = dynamic_cast<CXgate*>(gate)) {
                         if (argMap.at(cx->control).second == 1 && argMap.at(cx->target).second == 1) {
-                            return std::make_unique<qc::StandardOperation>(nqubits, dd::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first, qc::X);
+                            return std::make_unique<qc::StandardOperation>(nqubits, qc::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first, qc::X);
                         }
                     }
                 }
 
                 qc::CompoundOperation op(nqubits);
                 for (auto& gate: gateIt->second.gates) {
-                    if (auto u = dynamic_cast<SingleQubitGate*>(gate)) {
+                    if (auto* u = dynamic_cast<SingleQubitGate*>(gate)) {
                         std::unique_ptr<Expr> theta(RewriteExpr(u->theta, paramMap));
                         std::unique_ptr<Expr> phi(RewriteExpr(u->phi, paramMap));
                         std::unique_ptr<Expr> lambda(RewriteExpr(u->lambda, paramMap));
@@ -731,14 +765,14 @@ namespace qasm {
                                                                    theta ? theta->num : 0.);
                         } else {
                             // TODO: multiple targets could be useful here
-                            for (dd::QubitCount j = 0; j < argMap.at(u->target).second; ++j) {
-                                op.emplace_back<qc::StandardOperation>(nqubits, static_cast<dd::Qubit>(argMap.at(u->target).first + j), qc::U3, lambda->num, phi->num, theta->num);
+                            for (std::size_t j = 0; j < argMap.at(u->target).second; ++j) {
+                                op.emplace_back<qc::StandardOperation>(nqubits, argMap.at(u->target).first + j, qc::U3, lambda->num, phi->num, theta->num);
                             }
                         }
-                    } else if (auto cx = dynamic_cast<CXgate*>(gate)) {
+                    } else if (auto* cx = dynamic_cast<CXgate*>(gate)) {
                         // valid check
-                        for (int i = 0; i < argMap.at(cx->control).second; ++i) {
-                            for (int j = 0; j < argMap.at(cx->target).second; ++j) {
+                        for (std::size_t i = 0; i < argMap.at(cx->control).second; ++i) {
+                            for (std::size_t j = 0; j < argMap.at(cx->target).second; ++j) {
                                 if (argMap.at(cx->control).first + i == argMap.at(cx->target).first + j) {
                                     std::ostringstream oss{};
                                     oss << "Qubit " << argMap.at(cx->control).first + i << " cannot be control and target at the same time";
@@ -747,21 +781,24 @@ namespace qasm {
                             }
                         }
                         if (argMap.at(cx->control).second == 1 && argMap.at(cx->target).second == 1) {
-                            op.emplace_back<qc::StandardOperation>(nqubits, dd::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first, qc::X);
+                            op.emplace_back<qc::StandardOperation>(nqubits, qc::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first, qc::X);
                         } else if (argMap.at(cx->control).second == argMap.at(cx->target).second) {
-                            for (dd::QubitCount j = 0; j < argMap.at(cx->target).second; ++j)
-                                op.emplace_back<qc::StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(argMap.at(cx->control).first + j)}, argMap.at(cx->target).first + j, qc::X);
+                            for (std::size_t j = 0; j < argMap.at(cx->target).second; ++j) {
+                                op.emplace_back<qc::StandardOperation>(nqubits, qc::Control{static_cast<qc::Qubit>(argMap.at(cx->control).first + j)}, argMap.at(cx->target).first + j, qc::X);
+                            }
                         } else if (argMap.at(cx->control).second == 1) {
                             // TODO: multiple targets could be useful here
-                            for (dd::QubitCount k = 0; k < argMap.at(cx->target).second; ++k)
-                                op.emplace_back<qc::StandardOperation>(nqubits, dd::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first + k, qc::X);
+                            for (std::size_t k = 0; k < argMap.at(cx->target).second; ++k) {
+                                op.emplace_back<qc::StandardOperation>(nqubits, qc::Control{argMap.at(cx->control).first}, argMap.at(cx->target).first + k, qc::X);
+                            }
                         } else if (argMap.at(cx->target).second == 1) {
-                            for (dd::QubitCount l = 0; l < argMap.at(cx->control).second; ++l)
-                                op.emplace_back<qc::StandardOperation>(nqubits, dd::Control{static_cast<dd::Qubit>(argMap.at(cx->control).first + l)}, argMap.at(cx->target).first, qc::X);
+                            for (std::size_t l = 0; l < argMap.at(cx->control).second; ++l) {
+                                op.emplace_back<qc::StandardOperation>(nqubits, qc::Control{static_cast<qc::Qubit>(argMap.at(cx->control).first + l)}, argMap.at(cx->target).first, qc::X);
+                            }
                         } else {
                             error("Register size does not match for CX gate!");
                         }
-                    } else if (auto mcx = dynamic_cast<MCXgate*>(gate)) {
+                    } else if (auto* mcx = dynamic_cast<MCXgate*>(gate)) {
                         // valid check
                         for (const auto& control: mcx->controls) {
                             if (argMap.at(control).second != 1) {
@@ -782,11 +819,12 @@ namespace qasm {
                             error("Multi-controlled gates with whole qubit registers not supported");
                         }
 
-                        dd::Controls controls{};
-                        for (const auto& control: mcx->controls)
-                            controls.emplace(dd::Control{argMap.at(control).first});
+                        qc::Controls controls{};
+                        for (const auto& control: mcx->controls) {
+                            controls.emplace(qc::Control{argMap.at(control).first});
+                        }
                         op.emplace_back<qc::StandardOperation>(nqubits, controls, argMap.at(mcx->target).first);
-                    } else if (auto cu = dynamic_cast<CUgate*>(gate)) {
+                    } else if (auto* cu = dynamic_cast<CUgate*>(gate)) {
                         // valid check
                         for (const auto& control: cu->controls) {
                             if (argMap.at(control).second != 1) {
@@ -808,16 +846,17 @@ namespace qasm {
                         std::unique_ptr<Expr> phi(RewriteExpr(cu->phi, paramMap));
                         std::unique_ptr<Expr> lambda(RewriteExpr(cu->lambda, paramMap));
 
-                        dd::Controls controls{};
-                        for (const auto& control: cu->controls)
-                            controls.emplace(dd::Control{argMap.at(control).first});
+                        qc::Controls controls{};
+                        for (const auto& control: cu->controls) {
+                            controls.emplace(qc::Control{argMap.at(control).first});
+                        }
 
                         if (argMap.at(cu->target).second == 1) {
                             op.emplace_back<qc::StandardOperation>(nqubits, controls, argMap.at(cu->target).first, qc::U3, lambda->num, phi->num, theta->num);
-                        } else if (auto sw = dynamic_cast<SWAPgate*>(gate)) {
+                        } else if (auto* sw = dynamic_cast<SWAPgate*>(gate)) {
                             // valid check
-                            for (int i = 0; i < argMap.at(sw->target0).second; ++i) {
-                                for (int j = 0; j < argMap.at(sw->target1).second; ++j) {
+                            for (std::size_t i = 0; i < argMap.at(sw->target0).second; ++i) {
+                                for (std::size_t j = 0; j < argMap.at(sw->target1).second; ++j) {
                                     if (argMap.at(sw->target0).first + i == argMap.at(sw->target1).first + j) {
                                         std::ostringstream oss{};
                                         oss << "Qubit " << argMap.at(sw->target0).first + i << " cannot be swap target twice";
@@ -826,17 +865,20 @@ namespace qasm {
                                 }
                             }
                             if (argMap.at(sw->target0).second == 1 && argMap.at(sw->target1).second == 1) {
-                                op.emplace_back<qc::StandardOperation>(nqubits, dd::Controls{}, argMap.at(sw->target1).first, argMap.at(sw->target1).first, qc::SWAP);
+                                op.emplace_back<qc::StandardOperation>(nqubits, qc::Controls{}, argMap.at(sw->target1).first, argMap.at(sw->target1).first, qc::SWAP);
                             } else if (argMap.at(sw->target0).second == argMap.at(sw->target1).second) {
-                                for (unsigned short j = 0; j < argMap.at(sw->target1).second; ++j)
-                                    op.emplace_back<qc::StandardOperation>(nqubits, dd::Controls{}, argMap.at(sw->target0).first + j, argMap.at(sw->target1).first + j, qc::SWAP);
+                                for (std::size_t j = 0; j < argMap.at(sw->target1).second; ++j) {
+                                    op.emplace_back<qc::StandardOperation>(nqubits, qc::Controls{}, argMap.at(sw->target0).first + j, argMap.at(sw->target1).first + j, qc::SWAP);
+                                }
                             } else if (argMap.at(sw->target0).second == 1) {
                                 // TODO: multiple targets could be useful here
-                                for (unsigned short k = 0; k < argMap.at(sw->target1).second; ++k)
-                                    op.emplace_back<qc::StandardOperation>(nqubits, dd::Controls{}, argMap.at(sw->target0).first, argMap.at(sw->target1).first + k, qc::SWAP);
+                                for (std::size_t k = 0; k < argMap.at(sw->target1).second; ++k) {
+                                    op.emplace_back<qc::StandardOperation>(nqubits, qc::Controls{}, argMap.at(sw->target0).first, argMap.at(sw->target1).first + k, qc::SWAP);
+                                }
                             } else if (argMap.at(sw->target1).second == 1) {
-                                for (unsigned short l = 0; l < argMap.at(sw->target0).second; ++l)
-                                    op.emplace_back<qc::StandardOperation>(nqubits, dd::Controls{}, argMap.at(sw->target0).first + l, argMap.at(sw->target1).first, qc::SWAP);
+                                for (std::size_t l = 0; l < argMap.at(sw->target0).second; ++l) {
+                                    op.emplace_back<qc::StandardOperation>(nqubits, qc::Controls{}, argMap.at(sw->target0).first + l, argMap.at(sw->target1).first, qc::SWAP);
+                                }
                             } else {
                                 error("Register size does not match for SWAP gate!");
                             }
@@ -848,9 +890,8 @@ namespace qasm {
                     }
                 }
                 return std::make_unique<qc::CompoundOperation>(std::move(op));
-            } else {
-                error("Undefined gate " + t.str);
             }
+            error("Undefined gate " + t.str);
         } else {
             error("Symbol " + qasm::KindNames[sym] + " not expected in Gate() routine!");
         }
@@ -878,16 +919,17 @@ namespace qasm {
         check(Token::Kind::gate);
         // skip declarations of known gates
         if (sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase || sym == Token::Kind::swap || sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate) {
-            while (sym != Token::Kind::rbrace)
+            while (sym != Token::Kind::rbrace) {
                 scan();
+            }
 
             check(Token::Kind::rbrace);
             return;
         }
         check(Token::Kind::identifier);
 
-        CompoundGate gate;
-        std::string  gateName = t.str;
+        CompoundGate      gate;
+        const std::string gateName = t.str;
         if (sym == Token::Kind::lpar) {
             scan();
             if (sym != Token::Kind::rpar) {
@@ -898,8 +940,8 @@ namespace qasm {
         IdList(gate.argumentNames);
         check(Token::Kind::lbrace);
 
-        auto           cGateName = gateName;
-        dd::QubitCount ncontrols = 0;
+        auto        cGateName = gateName;
+        std::size_t ncontrols = 0;
         while (cGateName.front() == 'c') {
             cGateName = cGateName.substr(1);
             ncontrols++;
@@ -908,7 +950,9 @@ namespace qasm {
         auto controlledGateIt = compoundGates.find(cGateName);
         if (controlledGateIt != compoundGates.end() && controlledGateIt->second.gates.size() <= 1) {
             // skip over gate declaration
-            while (sym != Token::Kind::rbrace) scan();
+            while (sym != Token::Kind::rbrace) {
+                scan();
+            }
             scan();
             return;
         }
@@ -936,7 +980,7 @@ namespace qasm {
             } else if (sym == Token::Kind::cxgate) {
                 scan();
                 check(Token::Kind::identifier);
-                std::string control = t.str;
+                const std::string control = t.str;
                 check(Token::Kind::comma);
                 check(Token::Kind::identifier);
                 gate.gates.push_back(new CXgate(control, t.str));
@@ -966,9 +1010,10 @@ namespace qasm {
 
                 // drop ancillaries since our library can natively work with MCTs
                 if (type == Token::Kind::mcx_vchain) {
-                    dd::QubitCount ancillaries = (arguments.size() + 1) / 2 - 2;
-                    for (int i = 0; i < ancillaries; ++i)
+                    const auto ancillaries = (arguments.size() + 1) / 2 - 2;
+                    for (std::size_t i = 0; i < ancillaries; ++i) {
                         arguments.pop_back();
+                    }
                 } else if (type == Token::Kind::mcx_recursive) {
                     // 1 ancillary if more than 4 controls
                     if (arguments.size() > 5) {
@@ -1000,7 +1045,7 @@ namespace qasm {
                 gate.gates.push_back(new CUgate(theta, phi, lambda, arguments, target));
             } else if (sym == Token::Kind::identifier) {
                 scan();
-                std::string name = t.str;
+                const std::string name = t.str;
 
                 cGateName = name;
                 ncontrols = 0;
@@ -1042,23 +1087,26 @@ namespace qasm {
                         for (size_t i = 0; i < arguments.size(); ++i) {
                             argMap[gateIt->second.argumentNames[i]] = arguments[i];
                         }
-                        for (size_t i = 0; i < parameters.size(); ++i)
+                        for (size_t i = 0; i < parameters.size(); ++i) {
                             paramMap[gateIt->second.parameterNames[i]] = parameters[i];
+                        }
 
                         for (auto& it: gateIt->second.gates) {
-                            if (auto u = dynamic_cast<SingleQubitGate*>(it)) {
+                            if (auto* u = dynamic_cast<SingleQubitGate*>(it)) {
                                 gate.gates.push_back(new SingleQubitGate(argMap.at(u->target), u->type, RewriteExpr(u->lambda, paramMap), RewriteExpr(u->phi, paramMap), RewriteExpr(u->theta, paramMap)));
-                            } else if (auto cx = dynamic_cast<CXgate*>(it)) {
+                            } else if (auto* cx = dynamic_cast<CXgate*>(it)) {
                                 gate.gates.push_back(new CXgate(argMap.at(cx->control), argMap.at(cx->target)));
-                            } else if (auto cu = dynamic_cast<CUgate*>(it)) {
+                            } else if (auto* cu = dynamic_cast<CUgate*>(it)) {
                                 std::vector<std::string> controls{};
-                                for (const auto& control: cu->controls)
+                                for (const auto& control: cu->controls) {
                                     controls.emplace_back(argMap.at(control));
+                                }
                                 gate.gates.push_back(new CUgate(RewriteExpr(cu->theta, paramMap), RewriteExpr(cu->phi, paramMap), RewriteExpr(cu->lambda, paramMap), controls, argMap.at(cu->target)));
-                            } else if (auto mcx = dynamic_cast<MCXgate*>(it)) {
+                            } else if (auto* mcx = dynamic_cast<MCXgate*>(it)) {
                                 std::vector<std::string> controls{};
-                                for (const auto& control: mcx->controls)
+                                for (const auto& control: mcx->controls) {
                                     controls.emplace_back(argMap.at(control));
+                                }
                                 gate.gates.push_back(new MCXgate(controls, argMap.at(mcx->target)));
                             } else {
                                 error("Unexpected gate in GateDecl!");
@@ -1086,22 +1134,26 @@ namespace qasm {
                             error(oss.str());
                         }
 
-                        for (size_t i = 0; i < arguments.size(); ++i)
+                        for (size_t i = 0; i < arguments.size(); ++i) {
                             argMap["q" + std::to_string(i)] = arguments[i];
+                        }
 
-                        for (size_t i = 0; i < parameters.size(); ++i)
+                        for (size_t i = 0; i < parameters.size(); ++i) {
                             paramMap[cGateIt->second.parameterNames[i]] = parameters[i];
+                        }
 
                         if (cGateName == "x" || cGateName == "X") {
                             std::vector<std::string> controls{};
-                            for (size_t i = 0; i < arguments.size() - 1; ++i)
+                            for (size_t i = 0; i < arguments.size() - 1; ++i) {
                                 controls.emplace_back(arguments[i]);
+                            }
                             gate.gates.push_back(new MCXgate(controls, arguments.back()));
                         } else {
                             std::vector<std::string> controls{};
-                            for (size_t i = 0; i < arguments.size() - 1; ++i)
+                            for (size_t i = 0; i < arguments.size() - 1; ++i) {
                                 controls.emplace_back(arguments[i]);
-                            if (auto u = dynamic_cast<SingleQubitGate*>(cGateIt->second.gates.at(0))) {
+                            }
+                            if (auto* u = dynamic_cast<SingleQubitGate*>(cGateIt->second.gates.at(0))) {
                                 gate.gates.push_back(new CUgate(RewriteExpr(u->theta, paramMap), RewriteExpr(u->phi, paramMap), RewriteExpr(u->lambda, paramMap), controls, arguments.back()));
                             } else {
                                 throw QASMParserException("Could not cast to UGate in gate declaration.");
@@ -1135,9 +1187,10 @@ namespace qasm {
         if (sym == Token::Kind::ugate || sym == Token::Kind::cxgate ||
             sym == Token::Kind::swap || sym == Token::Kind::identifier ||
             sym == Token::Kind::sxgate || sym == Token::Kind::sxdggate ||
-            sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase)
+            sym == Token::Kind::mcx_gray || sym == Token::Kind::mcx_recursive || sym == Token::Kind::mcx_vchain || sym == Token::Kind::mcphase) {
             return Gate();
-        else if (sym == Token::Kind::measure) {
+        }
+        if (sym == Token::Kind::measure) {
             scan();
             auto qreg = ArgumentQreg();
             check(Token::Kind::minus);
@@ -1146,11 +1199,11 @@ namespace qasm {
             check(Token::Kind::semicolon);
 
             if (qreg.second == creg.second) {
-                std::vector<dd::Qubit>   qubits{};
-                std::vector<std::size_t> classics{};
-                for (int i = 0; i < qreg.second; ++i) {
-                    auto        qubit = static_cast<dd::Qubit>(qreg.first + i);
-                    std::size_t clbit = creg.first + i;
+                std::vector<qc::Qubit> qubits{};
+                std::vector<qc::Bit>   classics{};
+                for (std::size_t i = 0; i < qreg.second; ++i) {
+                    const auto qubit = qreg.first + i;
+                    const auto clbit = creg.first + i;
                     if (qubit >= nqubits) {
                         std::stringstream ss{};
                         ss << "Qubit " << qubit << " cannot be measured since the circuit only contains " << nqubits << " qubits";
@@ -1165,17 +1218,17 @@ namespace qasm {
                     classics.emplace_back(clbit);
                 }
                 return std::make_unique<qc::NonUnitaryOperation>(nqubits, qubits, classics);
-            } else {
-                error("Mismatch of qreg and creg size in measurement");
             }
-        } else if (sym == Token::Kind::reset) {
+            error("Mismatch of qreg and creg size in measurement");
+        }
+        if (sym == Token::Kind::reset) {
             scan();
             auto qreg = ArgumentQreg();
             check(Token::Kind::semicolon);
 
-            std::vector<dd::Qubit> qubits;
-            for (int i = 0; i < qreg.second; ++i) {
-                auto qubit = static_cast<dd::Qubit>(qreg.first + i);
+            std::vector<qc::Qubit> qubits;
+            for (std::size_t i = 0; i < qreg.second; ++i) {
+                auto qubit = qreg.first + i;
                 if (qubit >= nqubits) {
                     std::stringstream ss{};
                     ss << "Qubit " << qubit << " cannot be reset since the circuit only contains " << nqubits << " qubits";
@@ -1184,8 +1237,7 @@ namespace qasm {
                 qubits.emplace_back(qubit);
             }
             return std::make_unique<qc::NonUnitaryOperation>(nqubits, qubits);
-        } else {
-            error("No valid Qop: " + t.str);
         }
+        error("No valid Qop: " + t.str);
     }
 } // namespace qasm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT TARGET gtest OR NOT TARGET gmock)
 endif()
 
 add_executable(${PROJECT_NAME}_example ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME}_dd)
 set_target_properties(
   ${PROJECT_NAME}_example
   PROPERTIES FOLDER tests
@@ -47,11 +47,11 @@ add_custom_command(
   VERBATIM)
 
 # macro to add a test executable for one of the project libraries
-macro(PACKAGE_ADD_TEST testname)
+macro(PACKAGE_ADD_TEST testname linklibs)
   # create an executable in which the tests will be stored
   add_executable(${testname} ${ARGN})
   # link the Google test infrastructure and a default main function to the test executable.
-  target_link_libraries(${testname} PRIVATE ${PROJECT_NAME} gmock gtest_main)
+  target_link_libraries(${testname} PRIVATE ${linklibs} gmock gtest_main)
   # discover tests
   gtest_discover_tests(
     ${testname}
@@ -63,35 +63,36 @@ macro(PACKAGE_ADD_TEST testname)
                CMAKE_CXX_STANDARD_REQUIRED ON
                CXX_EXTENSIONS OFF)
   enable_lto(${testname})
+
+  add_custom_command(
+    TARGET ${testname}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/circuits
+            $<TARGET_FILE_DIR:${testname}>/circuits
+    COMMENT "Copying circuits for ${testname}"
+    VERBATIM)
 endmacro()
 
 # add unit tests
 package_add_test(
-  ${PROJECT_NAME}_test
+  ${PROJECT_NAME}_test ${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_io.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_qfr_functionality.cpp)
+
+package_add_test(
+  ${PROJECT_NAME}_test_dd
+  ${PROJECT_NAME}_dd
+  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_dd_functionality.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_dd_noise_functionality.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/eval_dynamic_circuits.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_qft.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grover.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_bernsteinvazirani.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_entanglement.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_grcs.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_random_clifford.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_qpe.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_io.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_dd_functionality.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_qfr_functionality.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/eval_dynamic_circuits.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_zx_functionality.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_symbolic.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_dd_noise_functionality.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/test_qpe.cpp)
 
-add_custom_command(
-  TARGET ${PROJECT_NAME}_test
-  POST_BUILD
-  COMMAND
-    ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${PROJECT_NAME}_test>/${PROJECT_NAME}_test
-    ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_test
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/circuits
-          $<TARGET_FILE_DIR:${PROJECT_NAME}_test>/circuits
-  COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${PROJECT_NAME}_test>/circuits
-          ${CMAKE_BINARY_DIR}/circuits
-  COMMENT "Copying circuits and creating symlinks for ${PROJECT_NAME}_test"
-  VERBATIM)
+package_add_test(
+  ${PROJECT_NAME}_test_zx ${PROJECT_NAME}_zx
+  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_zx_functionality.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/unittests/test_symbolic.cpp)

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -19,8 +19,8 @@
 
 class DynamicCircuitEvalExactQPE: public testing::TestWithParam<std::size_t> {
 protected:
-    dd::QubitCount                          precision{};
-    dd::fp                                  theta{};
+    std::size_t                             precision{};
+    qc::fp                                  theta{};
     std::size_t                             expectedResult{};
     std::string                             expectedResultRepresentation{};
     std::unique_ptr<qc::QuantumComputation> qpe;
@@ -45,7 +45,7 @@ protected:
         iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
         iqpeNgates        = iqpe->getNindividualOps();
 
-        std::cout << "Estimating lambda = " << lambda << "π up to " << static_cast<std::size_t>(precision) << "-bit precision." << std::endl;
+        std::cout << "Estimating lambda = " << lambda << "π up to " << precision << "-bit precision." << std::endl;
 
         theta = lambda / 2;
 
@@ -70,7 +70,7 @@ protected:
         }
         std::stringstream ss{};
         for (auto i = static_cast<int>(precision - 1); i >= 0; --i) {
-            if (expectedResult & (1ULL << i)) {
+            if ((expectedResult & (1ULL << i)) != 0) {
                 ss << 1;
             } else {
                 ss << 0;
@@ -78,7 +78,7 @@ protected:
         }
         expectedResultRepresentation = ss.str();
 
-        std::cout << "Theta is exactly representable using " << static_cast<std::size_t>(precision) << " bits." << std::endl;
+        std::cout << "Theta is exactly representable using " << precision << " bits." << std::endl;
         std::cout << "The expected output state is |" << expectedResultRepresentation << ">." << std::endl;
     }
 };
@@ -86,9 +86,9 @@ protected:
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalExactQPE,
                          testing::Range<std::size_t>(1U, 64U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
-                             dd::QubitCount nqubits = info.param;
+                             const auto nqubits = info.param;
                              std::stringstream ss{};
-                             ss << static_cast<std::size_t>(nqubits);
+                             ss << nqubits;
                              if (nqubits == 1) {
                                  ss << "_qubit";
                              } else {
@@ -154,7 +154,7 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
     const auto verification  = std::chrono::duration<double>(finishedEC - finishedTransformation).count();
 
     std::stringstream ss{};
-    ss << "qpe_exact,transformation," << static_cast<std::size_t>(qpe->getNqubits()) << "," << qpeNgates << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
+    ss << "qpe_exact,transformation," << qpe->getNqubits() << "," << qpeNgates << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
     std::cout << ss.str() << std::endl;
     ofs.open("results_exact.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -164,14 +164,14 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
 
 TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
     // generate DD of QPE circuit via simulation
-    const auto start          = std::chrono::steady_clock::now();
-    auto       e              = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
-    const auto simulation_end = std::chrono::steady_clock::now();
+    const auto start         = std::chrono::steady_clock::now();
+    auto       e             = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
+    const auto simulationEnd = std::chrono::steady_clock::now();
 
     // extract measurement probabilities from IQPE simulations
     dd::ProbabilityVector probs{};
     extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()), probs, dd);
-    const auto extraction_end = std::chrono::steady_clock::now();
+    const auto extractionEnd = std::chrono::steady_clock::now();
 
     // extend to account for 0 qubit
     auto stub = dd::ProbabilityVector{};
@@ -181,16 +181,16 @@ TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
     }
 
     // compare outcomes
-    auto       fidelity       = dd->fidelityOfMeasurementOutcomes(e, stub);
-    const auto comparison_end = std::chrono::steady_clock::now();
+    auto       fidelity      = dd->fidelityOfMeasurementOutcomes(e, stub);
+    const auto comparisonEnd = std::chrono::steady_clock::now();
 
-    const auto simulation = std::chrono::duration<double>(simulation_end - start).count();
-    const auto extraction = std::chrono::duration<double>(extraction_end - simulation_end).count();
-    const auto comparison = std::chrono::duration<double>(comparison_end - extraction_end).count();
-    const auto total      = std::chrono::duration<double>(comparison_end - start).count();
+    const auto simulation = std::chrono::duration<double>(simulationEnd - start).count();
+    const auto extraction = std::chrono::duration<double>(extractionEnd - simulationEnd).count();
+    const auto comparison = std::chrono::duration<double>(comparisonEnd - extractionEnd).count();
+    const auto total      = std::chrono::duration<double>(comparisonEnd - start).count();
 
     std::stringstream ss{};
-    ss << "qpe_exact,extraction," << static_cast<std::size_t>(qpe->getNqubits()) << "," << qpeNgates << ",2," << iqpeNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
+    ss << "qpe_exact,extraction," << qpe->getNqubits() << "," << qpeNgates << ",2," << iqpeNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
     std::cout << ss.str() << std::endl;
     ofs.open("results_exact_prob.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -228,7 +228,7 @@ protected:
         iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
         iqpeNgates        = iqpe->getNindividualOps();
 
-        std::cout << "Estimating lambda = " << lambda << "π up to " << static_cast<std::size_t>(precision) << "-bit precision." << std::endl;
+        std::cout << "Estimating lambda = " << lambda << "π up to " << precision << "-bit precision." << std::endl;
 
         theta = lambda / 2;
 
@@ -253,7 +253,7 @@ protected:
         }
         std::stringstream ss{};
         for (auto i = static_cast<int>(precision - 1); i >= 0; --i) {
-            if (expectedResult & (1ULL << i)) {
+            if ((expectedResult & (1ULL << i)) != 0) {
                 ss << 1;
             } else {
                 ss << 0;
@@ -264,7 +264,7 @@ protected:
         secondExpectedResult = expectedResult + 1;
         ss.str("");
         for (auto i = static_cast<int>(precision - 1); i >= 0; --i) {
-            if (secondExpectedResult & (1ULL << i)) {
+            if ((secondExpectedResult & (1ULL << i)) != 0) {
                 ss << 1;
             } else {
                 ss << 0;
@@ -272,7 +272,7 @@ protected:
         }
         secondExpectedResultRepresentation = ss.str();
 
-        std::cout << "Theta is not exactly representable using " << static_cast<std::size_t>(precision) << " bits." << std::endl;
+        std::cout << "Theta is not exactly representable using " << precision << " bits." << std::endl;
         std::cout << "Most probable output states are |" << expectedResultRepresentation << "> and |" << secondExpectedResultRepresentation << ">." << std::endl;
     }
 };
@@ -280,9 +280,9 @@ protected:
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalInexactQPE,
                          testing::Range<std::size_t>(1U, 15U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalInexactQPE::ParamType>& info) {
-            dd::QubitCount nqubits = info.param;
+            const auto nqubits = info.param;
             std::stringstream ss{};
-            ss << static_cast<std::size_t>(nqubits);
+            ss << nqubits;
             if (nqubits == 1) {
                 ss << "_qubit";
             } else {
@@ -348,7 +348,7 @@ TEST_P(DynamicCircuitEvalInexactQPE, UnitaryTransformation) {
     const auto verification  = std::chrono::duration<double>(finishedEC - finishedTransformation).count();
 
     std::stringstream ss{};
-    ss << "qpe_inexact,transformation," << static_cast<std::size_t>(qpe->getNqubits()) << "," << qpeNgates << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
+    ss << "qpe_inexact,transformation," << qpe->getNqubits() << "," << qpeNgates << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
     std::cout << ss.str() << std::endl;
     ofs.open("results_inexact.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -361,12 +361,12 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
     // extract measurement probabilities from IQPE simulations
     dd::ProbabilityVector probs{};
     extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()), probs, dd);
-    const auto extraction_end = std::chrono::steady_clock::now();
+    const auto extractionEnd = std::chrono::steady_clock::now();
     std::cout << "---- extraction done ----" << std::endl;
 
     // generate DD of QPE circuit via simulation
-    auto       e              = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
-    const auto simulation_end = std::chrono::steady_clock::now();
+    auto       e             = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
+    const auto simulationEnd = std::chrono::steady_clock::now();
     std::cout << "---- sim done ----" << std::endl;
 
     // extend to account for 0 qubit
@@ -377,16 +377,16 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
     }
 
     // compare outcomes
-    auto       fidelity       = dd->fidelityOfMeasurementOutcomes(e, stub);
-    const auto comparison_end = std::chrono::steady_clock::now();
+    auto       fidelity      = dd->fidelityOfMeasurementOutcomes(e, stub);
+    const auto comparisonEnd = std::chrono::steady_clock::now();
 
-    const auto extraction = std::chrono::duration<double>(extraction_end - start).count();
-    const auto simulation = std::chrono::duration<double>(simulation_end - extraction_end).count();
-    const auto comparison = std::chrono::duration<double>(comparison_end - simulation_end).count();
-    const auto total      = std::chrono::duration<double>(comparison_end - start).count();
+    const auto extraction = std::chrono::duration<double>(extractionEnd - start).count();
+    const auto simulation = std::chrono::duration<double>(simulationEnd - extractionEnd).count();
+    const auto comparison = std::chrono::duration<double>(comparisonEnd - simulationEnd).count();
+    const auto total      = std::chrono::duration<double>(comparisonEnd - start).count();
 
     std::stringstream ss{};
-    ss << "qpe_inexact,extraction," << static_cast<std::size_t>(qpe->getNqubits()) << "," << qpeNgates << ",2," << iqpeNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
+    ss << "qpe_inexact,extraction," << qpe->getNqubits() << "," << qpeNgates << ",2," << iqpeNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
     std::cout << ss.str() << std::endl;
     ofs.open("results_inexact_prob.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -420,16 +420,16 @@ protected:
         dbvNgates    = dbv->getNindividualOps();
 
         const auto expected = dynamic_cast<qc::BernsteinVazirani*>(bv.get())->expected;
-        std::cout << "Hidden bitstring: " << expected << " (" << static_cast<std::size_t>(bitwidth) << " qubits)" << std::endl;
+        std::cout << "Hidden bitstring: " << expected << " (" << bitwidth << " qubits)" << std::endl;
     }
 };
 
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalBV,
                          testing::Range<std::size_t>(1U, 64U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
-                             dd::QubitCount nqubits = info.param;
+                             const auto nqubits = info.param;
                              std::stringstream ss{};
-                             ss << static_cast<std::size_t>(nqubits);
+                             ss << nqubits;
                              if (nqubits == 1) {
                                  ss << "_qubit";
                              } else {
@@ -495,7 +495,7 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
     const auto verification  = std::chrono::duration<double>(finishedEC - finishedTransformation).count();
 
     std::stringstream ss{};
-    ss << "bv,transformation," << static_cast<std::size_t>(bv->getNqubits()) << "," << bvNgates << ",2," << dbvNgates << "," << preprocessing << "," << verification;
+    ss << "bv,transformation," << bv->getNqubits() << "," << bvNgates << ",2," << dbvNgates << "," << preprocessing << "," << verification;
     std::cout << ss.str() << std::endl;
     ofs.open("results_bv.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -505,14 +505,14 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
 
 TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
     // generate DD of QPE circuit via simulation
-    const auto start          = std::chrono::steady_clock::now();
-    auto       e              = simulate(bv.get(), dd->makeZeroState(bv->getNqubits()), dd);
-    const auto simulation_end = std::chrono::steady_clock::now();
+    const auto start         = std::chrono::steady_clock::now();
+    auto       e             = simulate(bv.get(), dd->makeZeroState(bv->getNqubits()), dd);
+    const auto simulationEnd = std::chrono::steady_clock::now();
 
     // extract measurement probabilities from IQPE simulations
     dd::ProbabilityVector probs{};
     extractProbabilityVector(dbv.get(), dd->makeZeroState(dbv->getNqubits()), probs, dd);
-    const auto extraction_end = std::chrono::steady_clock::now();
+    const auto extractionEnd = std::chrono::steady_clock::now();
 
     // extend to account for 0 qubit
     auto stub = dd::ProbabilityVector{};
@@ -522,16 +522,16 @@ TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
     }
 
     // compare outcomes
-    auto       fidelity       = dd->fidelityOfMeasurementOutcomes(e, stub);
-    const auto comparison_end = std::chrono::steady_clock::now();
+    auto       fidelity      = dd->fidelityOfMeasurementOutcomes(e, stub);
+    const auto comparisonEnd = std::chrono::steady_clock::now();
 
-    const auto simulation = std::chrono::duration<double>(simulation_end - start).count();
-    const auto extraction = std::chrono::duration<double>(extraction_end - simulation_end).count();
-    const auto comparison = std::chrono::duration<double>(comparison_end - extraction_end).count();
-    const auto total      = std::chrono::duration<double>(comparison_end - start).count();
+    const auto simulation = std::chrono::duration<double>(simulationEnd - start).count();
+    const auto extraction = std::chrono::duration<double>(extractionEnd - simulationEnd).count();
+    const auto comparison = std::chrono::duration<double>(comparisonEnd - extractionEnd).count();
+    const auto total      = std::chrono::duration<double>(comparisonEnd - start).count();
 
     std::stringstream ss{};
-    ss << "bv,extraction," << static_cast<std::size_t>(bv->getNqubits()) << "," << bvNgates << ",2," << dbvNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
+    ss << "bv,extraction," << bv->getNqubits() << "," << bvNgates << ",2," << dbvNgates << "," << simulation << "," << extraction << "," << comparison << "," << total;
     std::cout << ss.str() << std::endl;
     ofs.open("results_bv_prob.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -568,9 +568,9 @@ protected:
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalQFT,
                          testing::Range<std::size_t>(1U, 65U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
-                             dd::QubitCount nqubits = info.param;
+                             const auto nqubits = info.param;
                              std::stringstream ss{};
-                             ss << static_cast<std::size_t>(nqubits);
+                             ss << nqubits;
                              if (nqubits == 1) {
                                  ss << "_qubit";
                              } else {
@@ -636,7 +636,7 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
     const auto verification  = std::chrono::duration<double>(finishedEC - finishedTransformation).count();
 
     std::stringstream ss{};
-    ss << "qft,transformation," << static_cast<std::size_t>(qft->getNqubits()) << "," << qftNgates << ",1," << dqftNgates << "," << preprocessing << "," << verification;
+    ss << "qft,transformation," << qft->getNqubits() << "," << qftNgates << ",1," << dqftNgates << "," << preprocessing << "," << verification;
     std::cout << ss.str() << std::endl;
     ofs.open("results_qft.csv", std::ios_base::app);
     ofs << ss.str() << std::endl;
@@ -646,30 +646,30 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
 
 TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
     // generate DD of QPE circuit via simulation
-    const auto start          = std::chrono::steady_clock::now();
-    auto       e              = simulate(qft.get(), dd->makeZeroState(qft->getNqubits()), dd);
-    const auto simulation_end = std::chrono::steady_clock::now();
-    const auto simulation     = std::chrono::duration<double>(simulation_end - start).count();
+    const auto start         = std::chrono::steady_clock::now();
+    auto       e             = simulate(qft.get(), dd->makeZeroState(qft->getNqubits()), dd);
+    const auto simulationEnd = std::chrono::steady_clock::now();
+    const auto simulation    = std::chrono::duration<double>(simulationEnd - start).count();
 
     std::stringstream ss{};
     // extract measurement probabilities from IQPE simulations
     if (qft->getNqubits() <= 15) {
         dd::ProbabilityVector probs{};
         extractProbabilityVector(dqft.get(), dd->makeZeroState(dqft->getNqubits()), probs, dd);
-        const auto extraction_end = std::chrono::steady_clock::now();
+        const auto extractionEnd = std::chrono::steady_clock::now();
 
         // compare outcomes
-        auto       fidelity       = dd->fidelityOfMeasurementOutcomes(e, probs);
-        const auto comparison_end = std::chrono::steady_clock::now();
-        const auto extraction     = std::chrono::duration<double>(extraction_end - simulation_end).count();
-        const auto comparison     = std::chrono::duration<double>(comparison_end - extraction_end).count();
-        const auto total          = std::chrono::duration<double>(comparison_end - start).count();
+        auto       fidelity      = dd->fidelityOfMeasurementOutcomes(e, probs);
+        const auto comparisonEnd = std::chrono::steady_clock::now();
+        const auto extraction    = std::chrono::duration<double>(extractionEnd - simulationEnd).count();
+        const auto comparison    = std::chrono::duration<double>(comparisonEnd - extractionEnd).count();
+        const auto total         = std::chrono::duration<double>(comparisonEnd - start).count();
         EXPECT_NEAR(fidelity, 1.0, 1e-4);
-        ss << "qft,extraction," << static_cast<std::size_t>(qft->getNqubits()) << "," << qftNgates << ",1," << dqftNgates << "," << extraction << "," << simulation << "," << comparison << "," << total;
+        ss << "qft,extraction," << qft->getNqubits() << "," << qftNgates << ",1," << dqftNgates << "," << extraction << "," << simulation << "," << comparison << "," << total;
         std::cout << ss.str() << std::endl;
 
     } else {
-        ss << "qft,extraction," << static_cast<std::size_t>(qft->getNqubits()) << "," << qftNgates << ",1," << dqftNgates << ",," << simulation << ",,,";
+        ss << "qft,extraction," << qft->getNqubits() << "," << qftNgates << ",1," << dqftNgates << ",," << simulation << ",,,";
         std::cout << ss.str() << std::endl;
     }
 

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -84,7 +84,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalExactQPE,
-                         testing::Range<std::size_t>(1U, 64U),
+                         testing::Range<std::size_t>(1U, 64U, 5U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
                              const auto nqubits = info.param;
                              std::stringstream ss{};
@@ -278,7 +278,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalInexactQPE,
-                         testing::Range<std::size_t>(1U, 15U),
+                         testing::Range<std::size_t>(1U, 15U, 3U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalInexactQPE::ParamType>& info) {
             const auto nqubits = info.param;
             std::stringstream ss{};
@@ -425,7 +425,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalBV,
-                         testing::Range<std::size_t>(1U, 64U),
+                         testing::Range<std::size_t>(1U, 64U, 5U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
                              const auto nqubits = info.param;
                              std::stringstream ss{};
@@ -566,7 +566,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitEvalQFT,
-                         testing::Range<std::size_t>(1U, 65U),
+                         testing::Range<std::size_t>(1U, 65U, 5U),
                          [](const testing::TestParamInfo<DynamicCircuitEvalExactQPE::ParamType>& info) {
                              const auto nqubits = info.param;
                              std::stringstream ss{};

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -4,8 +4,6 @@
  */
 
 #include "QuantumComputation.hpp"
-#include "dd/FunctionalityConstruction.hpp"
-#include "dd/Simulation.hpp"
 
 #include "gtest/gtest.h"
 #include <fstream>
@@ -22,7 +20,7 @@ protected:
         qc = std::make_unique<qc::QuantumComputation>();
     }
 
-    dd::QubitCount                          nqubits = 0;
+    std::size_t                             nqubits = 0;
     unsigned int                            seed    = 0;
     std::string                             output  = "tmp.txt";
     std::string                             output2 = "tmp2.txt";
@@ -298,32 +296,6 @@ TEST_F(IO, classic_controlled) {
        << std::endl;
     EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM););
     std::cout << *qc << std::endl;
-}
-
-TEST_F(IO, changePermutation) {
-    std::stringstream ss{};
-    ss << "// o 1 0\n"
-       << "OPENQASM 2.0;"
-       << "include \"qelib1.inc\";"
-       << "qreg q[2];"
-       << "x q[0];"
-       << std::endl;
-    qc->import(ss, qc::Format::OpenQASM);
-    auto dd  = std::make_unique<dd::Package<>>();
-    auto sim = simulate(qc.get(), dd->makeZeroState(qc->getNqubits()), dd);
-    EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
-    EXPECT_TRUE(sim.p->e[1].w.approximatelyOne());
-    EXPECT_TRUE(sim.p->e[1].p->e[1].isZeroTerminal());
-    EXPECT_TRUE(sim.p->e[1].p->e[0].w.approximatelyOne());
-    auto func = buildFunctionality(qc.get(), dd);
-    EXPECT_FALSE(func.p->e[0].isZeroTerminal());
-    EXPECT_FALSE(func.p->e[1].isZeroTerminal());
-    EXPECT_FALSE(func.p->e[2].isZeroTerminal());
-    EXPECT_FALSE(func.p->e[3].isZeroTerminal());
-    EXPECT_TRUE(func.p->e[0].p->e[1].w.approximatelyOne());
-    EXPECT_TRUE(func.p->e[1].p->e[3].w.approximatelyOne());
-    EXPECT_TRUE(func.p->e[2].p->e[0].w.approximatelyOne());
-    EXPECT_TRUE(func.p->e[3].p->e[2].w.approximatelyOne());
 }
 
 TEST_F(IO, iSWAP_dump_is_valid) {

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -6,9 +6,7 @@
 #include "QuantumComputation.hpp"
 
 #include "gtest/gtest.h"
-#include <fstream>
 #include <iostream>
-#include <streambuf>
 #include <string>
 
 class IO: public testing::TestWithParam<std::tuple<std::string, qc::Format>> {
@@ -27,7 +25,7 @@ protected:
     std::unique_ptr<qc::QuantumComputation> qc;
 };
 
-void compare_files(const std::string& file1, const std::string& file2, bool stripWhitespaces = false) {
+void compareFiles(const std::string& file1, const std::string& file2, bool stripWhitespaces = false) {
     std::ifstream fstream1(file1);
     std::string   str1((std::istreambuf_iterator<char>(fstream1)),
                        std::istreambuf_iterator<char>());
@@ -45,7 +43,7 @@ INSTANTIATE_TEST_SUITE_P(IO,
                          IO,
                          testing::Values(std::make_tuple("./circuits/test.qasm", qc::Format::OpenQASM)), //std::make_tuple("circuits/test.real", qc::Format::Real
                          [](const testing::TestParamInfo<IO::ParamType>& info) {
-                             qc::Format format = std::get<1>(info.param);
+                             const qc::Format format = std::get<1>(info.param);
 
                              switch (format) {
                                  case qc::Format::Real:
@@ -68,7 +66,7 @@ TEST_P(IO, importAndDump) {
     ASSERT_NO_THROW(qc->import(output, format));
     ASSERT_NO_THROW(qc->dump(output2, format));
 
-    compare_files(output, output2, true);
+    compareFiles(output, output2, true);
 }
 
 TEST_F(IO, importFromString) {
@@ -368,7 +366,7 @@ TEST_F(IO, sx_and_sxdag) {
     EXPECT_EQ(op2->getType(), qc::OpType::SXdag);
     auto& op3 = *(++(++qc->begin()));
     ASSERT_TRUE(op3->isCompoundOperation());
-    auto  compOp  = dynamic_cast<qc::CompoundOperation*>(op3.get());
+    auto* compOp  = dynamic_cast<qc::CompoundOperation*>(op3.get());
     auto& compOp1 = *(compOp->begin());
     EXPECT_EQ(compOp1->getType(), qc::OpType::SX);
     auto& compOp2 = *(++compOp->begin());

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -29,14 +29,14 @@ protected:
     std::unique_ptr<qc::QuantumComputation> qc;
 };
 
-void compare_files(const std::string& file1, const std::string& file2, bool strip_whitespaces = false) {
+void compare_files(const std::string& file1, const std::string& file2, bool stripWhitespaces = false) {
     std::ifstream fstream1(file1);
     std::string   str1((std::istreambuf_iterator<char>(fstream1)),
                        std::istreambuf_iterator<char>());
     std::ifstream fstream2(file2);
     std::string   str2((std::istreambuf_iterator<char>(fstream2)),
                        std::istreambuf_iterator<char>());
-    if (strip_whitespaces) {
+    if (stripWhitespaces) {
         str1.erase(std::remove_if(str1.begin(), str1.end(), isspace), str1.end());
         str2.erase(std::remove_if(str2.begin(), str2.end(), isspace), str2.end());
     }
@@ -45,25 +45,23 @@ void compare_files(const std::string& file1, const std::string& file2, bool stri
 
 INSTANTIATE_TEST_SUITE_P(IO,
                          IO,
-                         testing::Values(std::make_tuple("./circuits/test.qasm", qc::OpenQASM)), //std::make_tuple("circuits/test.real", qc::Real
+                         testing::Values(std::make_tuple("./circuits/test.qasm", qc::Format::OpenQASM)), //std::make_tuple("circuits/test.real", qc::Format::Real
                          [](const testing::TestParamInfo<IO::ParamType>& info) {
                              qc::Format format = std::get<1>(info.param);
 
                              switch (format) {
-                                 case qc::Real:
+                                 case qc::Format::Real:
                                      return "Real";
-                                 case qc::OpenQASM:
+                                 case qc::Format::OpenQASM:
                                      return "OpenQasm";
-                                 case qc::GRCS:
+                                 case qc::Format::GRCS:
                                      return "GRCS";
                                  default: return "Unknown format";
                              }
                          });
 
 TEST_P(IO, importAndDump) {
-    std::string input;
-    qc::Format  format;
-    std::tie(input, format) = GetParam();
+    const auto& [input, format] = GetParam();
     std::cout << "FILE: " << input << std::endl;
 
     ASSERT_NO_THROW(qc->import(input, format));
@@ -76,63 +74,63 @@ TEST_P(IO, importAndDump) {
 }
 
 TEST_F(IO, importFromString) {
-    std::string       bell_circuit_qasm = "OPENQASM 2.0;\nqreg q[2];\nU(pi/2,0,pi) q[0];\nCX q[0],q[1];\n";
-    std::stringstream ss{bell_circuit_qasm};
-    ASSERT_NO_THROW(qc->import(ss, qc::OpenQASM));
+    const std::string bellCircuitQasm = "OPENQASM 2.0;\nqreg q[2];\nU(pi/2,0,pi) q[0];\nCX q[0],q[1];\n";
+    std::stringstream ss{bellCircuitQasm};
+    ASSERT_NO_THROW(qc->import(ss, qc::Format::OpenQASM));
     std::cout << *qc << std::endl;
-    std::string bell_circuit_real = ".numvars 2\n.variables q0 q1\n.begin\nh1 q0\nt2 q0 q1\n.end\n";
+    const std::string bellCircuitReal = ".numvars 2\n.variables q0 q1\n.begin\nh1 q0\nt2 q0 q1\n.end\n";
     ss.clear();
-    ss.str(bell_circuit_real);
-    ASSERT_NO_THROW(qc->import(ss, qc::Real));
+    ss.str(bellCircuitReal);
+    ASSERT_NO_THROW(qc->import(ss, qc::Format::Real));
     std::cout << *qc << std::endl;
 }
 
 TEST_F(IO, controlled_op_acting_on_whole_register) {
-    std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q,q[1];\n";
-    std::stringstream ss{circuit_qasm};
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    const std::string circuitQasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q,q[1];\n";
+    std::stringstream ss{circuitQasm};
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, invalid_real_header) {
-    std::string       circuit_real = ".numvars 2\nvariables q0 q1\n.begin\nh1 q0\nt2 q0 q1\n.end\n";
-    std::stringstream ss{circuit_real};
-    EXPECT_THROW(qc->import(ss, qc::Real), qc::QFRException);
+    const std::string circuitReal = ".numvars 2\nvariables q0 q1\n.begin\nh1 q0\nt2 q0 q1\n.end\n";
+    std::stringstream ss{circuitReal};
+    EXPECT_THROW(qc->import(ss, qc::Format::Real), qc::QFRException);
 }
 
 TEST_F(IO, invalid_real_command) {
-    std::string       circuit_real = ".numvars 2\n.var q0 q1\n.begin\nh1 q0\n# test comment\nt2 q0 q1\n.end\n";
-    std::stringstream ss{circuit_real};
-    EXPECT_THROW(qc->import(ss, qc::Real), qc::QFRException);
+    const std::string circuitReal = ".numvars 2\n.var q0 q1\n.begin\nh1 q0\n# test comment\nt2 q0 q1\n.end\n";
+    std::stringstream ss{circuitReal};
+    EXPECT_THROW(qc->import(ss, qc::Format::Real), qc::QFRException);
 }
 
 TEST_F(IO, insufficient_registers_qelib) {
-    std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q[0];\n";
-    std::stringstream ss{circuit_qasm};
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    const std::string circuitQasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx q[0];\n";
+    std::stringstream ss{circuitQasm};
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, insufficient_registers_enhanced_qelib) {
-    std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[4];\ncccz q[0], q[1], q[2];\n";
-    std::stringstream ss{circuit_qasm};
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    const std::string circuitQasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[4];\ncccz q[0], q[1], q[2];\n";
+    std::stringstream ss{circuitQasm};
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, superfluous_registers_qelib) {
-    std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[3];\ncx q[0], q[1], q[2];\n";
-    std::stringstream ss{circuit_qasm};
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    const std::string circuitQasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[3];\ncx q[0], q[1], q[2];\n";
+    std::stringstream ss{circuitQasm};
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, superfluous_registers_enhanced_qelib) {
-    std::string       circuit_qasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[5];\ncccz q[0], q[1], q[2], q[3], q[4];\n";
-    std::stringstream ss{circuit_qasm};
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    const std::string circuitQasm = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[5];\ncccz q[0], q[1], q[2], q[3], q[4];\n";
+    std::stringstream ss{circuitQasm};
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, dump_negative_control) {
-    std::string       circuit_real = ".numvars 2\n.variables a b\n.begin\nt2 -a b\n.end";
-    std::stringstream ss{circuit_real};
-    qc->import(ss, qc::Real);
+    const std::string circuitReal = ".numvars 2\n.variables a b\n.begin\nt2 -a b\n.end";
+    std::stringstream ss{circuitReal};
+    qc->import(ss, qc::Format::Real);
     qc->dump("testdump.qasm");
     qc->import("testdump.qasm");
     ASSERT_EQ(qc->getNops(), 3);
@@ -154,7 +152,7 @@ TEST_F(IO, qiskit_mcx_gray) {
        << "qreg q[4];"
        << "mcx_gray q[0], q[1], q[2], q[3];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto& gate = *(qc->begin());
     std::cout << *qc << std::endl;
     EXPECT_EQ(gate->getType(), qc::X);
@@ -170,7 +168,7 @@ TEST_F(IO, qiskit_mcx_skip_gate_definition) {
        << "gate mcx q0,q1,q2,q3 { cccx q0,q1,q2,q3; }"
        << "mcx q[0], q[1], q[2], q[3];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto& gate = *(qc->begin());
     std::cout << *qc << std::endl;
     EXPECT_EQ(gate->getType(), qc::X);
@@ -185,7 +183,7 @@ TEST_F(IO, qiskit_mcphase) {
        << "qreg q[4];"
        << "mcphase(pi) q[0], q[1], q[2], q[3];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto& gate = *(qc->begin());
     std::cout << *qc << std::endl;
     EXPECT_EQ(gate->getType(), qc::Z);
@@ -201,7 +199,7 @@ TEST_F(IO, qiskit_mcphase_in_declaration) {
        << "gate foo q0, q1, q2, q3 { mcphase(pi) q0, q1, q2, q3; }"
        << "foo q[0], q[1], q[2], q[3];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto&       gate     = *(qc->begin());
     auto*       compound = dynamic_cast<qc::CompoundOperation*>(gate.get());
     const auto& op       = compound->at(0);
@@ -220,7 +218,7 @@ TEST_F(IO, qiskit_mcx_recursive) {
        << "mcx_recursive q[0], q[1], q[2], q[3], q[4];"
        << "mcx_recursive q[0], q[1], q[2], q[3], q[4], q[5], anc[0];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto& gate = *(qc->begin());
     std::cout << *qc << std::endl;
     EXPECT_EQ(gate->getType(), qc::X);
@@ -240,7 +238,7 @@ TEST_F(IO, qiskit_mcx_vchain) {
        << "qreg anc[1];"
        << "mcx_vchain q[0], q[1], q[2], q[3], anc[0];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto& gate = *(qc->begin());
     std::cout << *qc << std::endl;
     EXPECT_EQ(gate->getType(), qc::X);
@@ -256,7 +254,7 @@ TEST_F(IO, qiskit_mcx_duplicate_qubit) {
        << "qreg anc[1];"
        << "mcx_vchain q[0], q[0], q[2], q[3], anc[0];"
        << std::endl;
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, qiskit_mcx_qubit_register) {
@@ -267,7 +265,7 @@ TEST_F(IO, qiskit_mcx_qubit_register) {
        << "qreg anc[1];"
        << "mcx_vchain q, q[0], q[2], q[3], anc[0];"
        << std::endl;
-    EXPECT_THROW(qc->import(ss, qc::OpenQASM), qasm::QASMParserException);
+    EXPECT_THROW(qc->import(ss, qc::Format::OpenQASM), qasm::QASMParserException);
 }
 
 TEST_F(IO, tfc_input) {
@@ -298,7 +296,7 @@ TEST_F(IO, classic_controlled) {
        << "// test classic controlled operation\n"
        << "if (c==1) x q[0];"
        << std::endl;
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM););
     std::cout << *qc << std::endl;
 }
 
@@ -310,7 +308,7 @@ TEST_F(IO, changePermutation) {
        << "qreg q[2];"
        << "x q[0];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     auto dd  = std::make_unique<dd::Package<>>();
     auto sim = simulate(qc.get(), dd->makeZeroState(qc->getNqubits()), dd);
     EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
@@ -334,7 +332,7 @@ TEST_F(IO, iSWAP_dump_is_valid) {
     std::cout << *qc << std::endl;
     std::stringstream ss{};
     qc->dumpOpenQASM(ss);
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM););
     std::cout << *qc << std::endl;
 }
 
@@ -344,7 +342,7 @@ TEST_F(IO, Peres_dump_is_valid) {
     std::cout << *qc << std::endl;
     std::stringstream ss{};
     qc->dumpOpenQASM(ss);
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM););
     std::cout << *qc << std::endl;
 }
 
@@ -354,7 +352,7 @@ TEST_F(IO, Peresdag_dump_is_valid) {
     std::cout << *qc << std::endl;
     std::stringstream ss{};
     qc->dumpOpenQASM(ss);
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM););
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM););
     std::cout << *qc << std::endl;
 }
 
@@ -371,7 +369,7 @@ TEST_F(IO, printing_non_unitary) {
        << "barrier q;"
        << "measure q -> c;"
        << std::endl;
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM));
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM));
     std::cout << *qc << std::endl;
     for (const auto& op: *qc) {
         op->print(std::cout);
@@ -390,7 +388,7 @@ TEST_F(IO, sx_and_sxdag) {
        << "sxdg q[0];"
        << "test q[0];"
        << std::endl;
-    EXPECT_NO_THROW(qc->import(ss, qc::OpenQASM));
+    EXPECT_NO_THROW(qc->import(ss, qc::Format::OpenQASM));
     std::cout << *qc << std::endl;
     auto& op1 = *(qc->begin());
     EXPECT_EQ(op1->getType(), qc::OpType::SX);
@@ -414,12 +412,12 @@ TEST_F(IO, unify_registers) {
        << "x q[0];"
        << "x r[0];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     std::cout << *qc << std::endl;
     qc->unifyQuantumRegisters();
     std::cout << *qc << std::endl;
     std::ostringstream oss{};
-    qc->dump(oss, qc::OpenQASM);
+    qc->dump(oss, qc::Format::OpenQASM);
     EXPECT_STREQ(oss.str().c_str(),
                  "// i 0 1\n"
                  "// o 0 1\n"
@@ -438,7 +436,7 @@ TEST_F(IO, append_measurements_according_to_output_permutation) {
        << "qreg q[2];"
        << "x q[1];"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     qc->appendMeasurementsAccordingToOutputPermutation();
     std::cout << *qc << std::endl;
     const auto& op = *(qc->rbegin());
@@ -459,7 +457,7 @@ TEST_F(IO, append_measurements_according_to_output_permutation_augment_register)
        << "creg c[1];"
        << "x q;"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     qc->appendMeasurementsAccordingToOutputPermutation();
     std::cout << *qc << std::endl;
     EXPECT_EQ(qc->getNcbits(), 2U);
@@ -478,7 +476,7 @@ TEST_F(IO, append_measurements_according_to_output_permutation_augment_register)
     EXPECT_EQ(meas2->getClassics().size(), 1U);
     EXPECT_EQ(meas2->getClassics().front(), 0U);
     std::ostringstream oss{};
-    qc->dump(oss, qc::OpenQASM);
+    qc->dump(oss, qc::Format::OpenQASM);
     std::cout << oss.str() << std::endl;
     EXPECT_STREQ(oss.str().c_str(),
                  "// i 0 1\n"
@@ -502,7 +500,7 @@ TEST_F(IO, append_measurements_according_to_output_permutation_add_register) {
        << "creg d[1];"
        << "x q;"
        << std::endl;
-    qc->import(ss, qc::OpenQASM);
+    qc->import(ss, qc::Format::OpenQASM);
     qc->appendMeasurementsAccordingToOutputPermutation();
     std::cout << *qc << std::endl;
     EXPECT_EQ(qc->getNcbits(), 2U);
@@ -521,7 +519,7 @@ TEST_F(IO, append_measurements_according_to_output_permutation_add_register) {
     EXPECT_EQ(meas2->getClassics().size(), 1U);
     EXPECT_EQ(meas2->getClassics().front(), 0U);
     std::ostringstream oss{};
-    qc->dump(oss, qc::OpenQASM);
+    qc->dump(oss, qc::Format::OpenQASM);
     std::cout << oss.str() << std::endl;
     EXPECT_STREQ(oss.str().c_str(),
                  "// i 0 1\n"

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -195,7 +195,7 @@ TEST_F(QFRFunctionality, split_qreg) {
 
 TEST_F(QFRFunctionality, StripIdleAndDump) {
     std::stringstream ss{};
-    auto              testfile =
+    const std::string testfile =
             "OPENQASM 2.0;\n"
             "include \"qelib1.inc\";\n"
             "qreg q[5];\n"
@@ -647,7 +647,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsWithOperationsInFront) {
-    auto              circ = "OPENQASM 2.0;include \"qelib1.inc\";qreg q[3];qreg r[3];h q;cx q, r;creg c[3];creg d[3];barrier q;measure q->c;measure r->d;\n";
+    const std::string circ = "OPENQASM 2.0;include \"qelib1.inc\";qreg q[3];qreg r[3];h q;cx q, r;creg c[3];creg d[3];barrier q;measure q->c;measure r->d;\n";
     std::stringstream ss{};
     ss << circ;
     QuantumComputation qc{};
@@ -739,8 +739,8 @@ TEST_F(QFRFunctionality, gateShortCutsAndCloning) {
     qc.reset(0);
     qc.reset({1, 2});
 
-    auto qc_cloned = qc.clone();
-    ASSERT_EQ(qc.size(), qc_cloned.size());
+    auto qcCloned = qc.clone();
+    ASSERT_EQ(qc.size(), qcCloned.size());
 }
 
 TEST_F(QFRFunctionality, cloningDifferentOperations) {
@@ -753,8 +753,8 @@ TEST_F(QFRFunctionality, cloningDifferentOperations) {
     qc.classicControlled(qc::X, 0, qc.getCregs().at("c"), 1);
     qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), std::vector<Qubit>{0, 1}, 1);
 
-    auto qc_cloned = qc.clone();
-    ASSERT_EQ(qc.size(), qc_cloned.size());
+    auto qcCloned = qc.clone();
+    ASSERT_EQ(qc.size(), qcCloned.size());
 }
 
 TEST_F(QFRFunctionality, wrongRegisterSizes) {
@@ -783,10 +783,10 @@ TEST_F(QFRFunctionality, eliminateResetsBasicTest) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 4);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
-    auto& op3 = qc.at(3);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
+    const auto& op3 = qc.at(3);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -801,7 +801,7 @@ TEST_F(QFRFunctionality, eliminateResetsBasicTest) {
     EXPECT_EQ(targets1.size(), 1);
     EXPECT_EQ(targets1.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op1->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
@@ -819,7 +819,7 @@ TEST_F(QFRFunctionality, eliminateResetsBasicTest) {
     EXPECT_EQ(targets3.size(), 1);
     EXPECT_EQ(targets3.at(0), static_cast<Qubit>(1));
     EXPECT_TRUE(op3->getControls().empty());
-    auto        measure1  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+    auto*       measure1  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
     const auto& classics1 = measure1->getClassics();
     EXPECT_EQ(classics1.size(), 1);
     EXPECT_EQ(classics1.at(0), 1);
@@ -843,9 +843,9 @@ TEST_F(QFRFunctionality, eliminateResetsClassicControlled) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 3);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -860,14 +860,14 @@ TEST_F(QFRFunctionality, eliminateResetsClassicControlled) {
     EXPECT_EQ(targets1.size(), 1);
     EXPECT_EQ(targets1.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op1->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
 
     EXPECT_EQ(op2->getNqubits(), 2);
     EXPECT_TRUE(op2->isClassicControlledOperation());
-    auto        classicControlled = dynamic_cast<qc::ClassicControlledOperation*>(op2.get());
+    auto*       classicControlled = dynamic_cast<qc::ClassicControlledOperation*>(op2.get());
     const auto& operation         = classicControlled->getOperation();
     EXPECT_EQ(operation->getNqubits(), 2);
     EXPECT_TRUE(operation->getType() == qc::X);
@@ -895,9 +895,9 @@ TEST_F(QFRFunctionality, eliminateResetsMultipleTargetReset) {
 
     ASSERT_EQ(qc.getNqubits(), 4);
     ASSERT_EQ(qc.getNindividualOps(), 3);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
 
     EXPECT_EQ(op0->getNqubits(), 4);
     EXPECT_TRUE(op0->getType() == qc::X);
@@ -947,15 +947,15 @@ TEST_F(QFRFunctionality, eliminateResetsCompoundOperation) {
     ASSERT_EQ(qc.getNqubits(), 5);
     ASSERT_EQ(qc.getNindividualOps(), 3);
 
-    auto& op = qc.at(0);
+    const auto& op = qc.at(0);
     EXPECT_TRUE(op->isCompoundOperation());
     EXPECT_EQ(op->getNqubits(), 5);
-    auto compOp0 = dynamic_cast<qc::CompoundOperation*>(op.get());
+    auto* compOp0 = dynamic_cast<qc::CompoundOperation*>(op.get());
     EXPECT_EQ(compOp0->size(), 3);
 
-    auto& op0 = compOp0->at(0);
-    auto& op1 = compOp0->at(1);
-    auto& op2 = compOp0->at(2);
+    const auto& op0 = compOp0->at(0);
+    const auto& op1 = compOp0->at(1);
+    const auto& op2 = compOp0->at(2);
 
     EXPECT_EQ(op0->getNqubits(), 5);
     EXPECT_TRUE(op0->getType() == qc::X);
@@ -972,14 +972,14 @@ TEST_F(QFRFunctionality, eliminateResetsCompoundOperation) {
     EXPECT_EQ(targets1.size(), 1);
     EXPECT_EQ(targets1.at(0), static_cast<Qubit>(4));
     EXPECT_TRUE(op1->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op1.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
 
     EXPECT_EQ(op2->getNqubits(), 5);
     EXPECT_TRUE(op2->isClassicControlledOperation());
-    auto        classicControlled = dynamic_cast<qc::ClassicControlledOperation*>(op2.get());
+    auto*       classicControlled = dynamic_cast<qc::ClassicControlledOperation*>(op2.get());
     const auto& operation         = classicControlled->getOperation();
     EXPECT_EQ(operation->getNqubits(), 5);
     EXPECT_TRUE(operation->getType() == qc::X);
@@ -1022,9 +1022,9 @@ TEST_F(QFRFunctionality, deferMeasurementsBasicTest) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 3);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -1048,7 +1048,7 @@ TEST_F(QFRFunctionality, deferMeasurementsBasicTest) {
     EXPECT_EQ(targets2.size(), 1);
     EXPECT_EQ(targets2.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op2->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op2.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op2.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
@@ -1090,10 +1090,10 @@ TEST_F(QFRFunctionality, deferMeasurementsOperationBetweenMeasurementAndClassic)
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 4);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
-    auto& op3 = qc.at(3);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
+    const auto& op3 = qc.at(3);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -1124,7 +1124,7 @@ TEST_F(QFRFunctionality, deferMeasurementsOperationBetweenMeasurementAndClassic)
     EXPECT_EQ(targets3.size(), 1);
     EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op3->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
@@ -1170,11 +1170,11 @@ TEST_F(QFRFunctionality, deferMeasurementsTwoClassic) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 5);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
-    auto& op3 = qc.at(3);
-    auto& op4 = qc.at(4);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
+    const auto& op3 = qc.at(3);
+    const auto& op4 = qc.at(4);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -1214,7 +1214,7 @@ TEST_F(QFRFunctionality, deferMeasurementsTwoClassic) {
     EXPECT_EQ(targets4.size(), 1);
     EXPECT_EQ(targets4.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op4->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
@@ -1256,10 +1256,10 @@ TEST_F(QFRFunctionality, deferMeasurementsCorrectOrder) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 4);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
-    auto& op3 = qc.at(3);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
+    const auto& op3 = qc.at(3);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -1290,7 +1290,7 @@ TEST_F(QFRFunctionality, deferMeasurementsCorrectOrder) {
     EXPECT_EQ(targets3.size(), 1);
     EXPECT_EQ(targets3.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op3->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op3.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);
@@ -1335,11 +1335,11 @@ TEST_F(QFRFunctionality, deferMeasurementsTwoClassicCorrectOrder) {
 
     ASSERT_EQ(qc.getNqubits(), 2);
     ASSERT_EQ(qc.getNindividualOps(), 5);
-    auto& op0 = qc.at(0);
-    auto& op1 = qc.at(1);
-    auto& op2 = qc.at(2);
-    auto& op3 = qc.at(3);
-    auto& op4 = qc.at(4);
+    const auto& op0 = qc.at(0);
+    const auto& op1 = qc.at(1);
+    const auto& op2 = qc.at(2);
+    const auto& op3 = qc.at(3);
+    const auto& op4 = qc.at(4);
 
     EXPECT_EQ(op0->getNqubits(), 2);
     EXPECT_TRUE(op0->getType() == qc::H);
@@ -1379,7 +1379,7 @@ TEST_F(QFRFunctionality, deferMeasurementsTwoClassicCorrectOrder) {
     EXPECT_EQ(targets4.size(), 1);
     EXPECT_EQ(targets4.at(0), static_cast<Qubit>(0));
     EXPECT_TRUE(op4->getControls().empty());
-    auto        measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
+    auto*       measure0  = dynamic_cast<qc::NonUnitaryOperation*>(op4.get());
     const auto& classics0 = measure0->getClassics();
     EXPECT_EQ(classics0.size(), 1);
     EXPECT_EQ(classics0.at(0), 0);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -14,7 +14,6 @@
 #include <random>
 
 using namespace qc;
-using namespace dd;
 
 class QFRFunctionality: public testing::TestWithParam<dd::QubitCount> {
 protected:
@@ -35,7 +34,7 @@ protected:
 };
 
 TEST_F(QFRFunctionality, fuse_cx_to_swap) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.x(1, 0_pc);
     qc.x(0, 1_pc);
@@ -50,7 +49,7 @@ TEST_F(QFRFunctionality, fuse_cx_to_swap) {
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.x(1, 0_pc);
     qc.x(0, 1_pc);
@@ -72,7 +71,7 @@ TEST_F(QFRFunctionality, replace_cx_to_swap_at_end) {
 }
 
 TEST_F(QFRFunctionality, replace_cx_to_swap) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.x(1, 0_pc);
     qc.x(0, 1_pc);
@@ -95,7 +94,7 @@ TEST_F(QFRFunctionality, replace_cx_to_swap) {
 }
 
 TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
-    const QubitCount   nqubits = 4;
+    const std::size_t  nqubits = 4;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.x(2);
@@ -123,7 +122,7 @@ TEST_F(QFRFunctionality, remove_trailing_idle_qubits) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.addAncillaryRegister(1);
@@ -183,7 +182,7 @@ TEST_F(QFRFunctionality, ancillary_qubit_at_end) {
 }
 
 TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.addAncillaryRegister(3);
@@ -197,7 +196,7 @@ TEST_F(QFRFunctionality, ancillary_qubit_remove_middle) {
 }
 
 TEST_F(QFRFunctionality, split_qreg) {
-    const QubitCount   nqubits = 3;
+    const std::size_t  nqubits = 3;
     QuantumComputation qc(nqubits);
     qc.x(0);
     auto p = qc.removeQubit(1);
@@ -210,7 +209,7 @@ TEST_F(QFRFunctionality, split_qreg) {
 }
 
 TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.h(0);
@@ -226,7 +225,7 @@ TEST_F(QFRFunctionality, FuseTwoSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.h(0);
@@ -244,7 +243,7 @@ TEST_F(QFRFunctionality, FuseThreeSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.h(0);
     qc.x(1, 0_pc);
@@ -261,7 +260,7 @@ TEST_F(QFRFunctionality, FuseNoSingleQubitGates) {
 }
 
 TEST_F(QFRFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.h(0);
     qc.z(1);
@@ -294,17 +293,17 @@ TEST_F(QFRFunctionality, StripIdleAndDump) {
 
     ss << testfile;
     auto qc = qc::QuantumComputation();
-    qc.import(ss, qc::OpenQASM);
+    qc.import(ss, qc::Format::OpenQASM);
     qc.print(std::cout);
     qc.stripIdleQubits();
     qc.print(std::cout);
     std::stringstream goal{};
     qc.print(goal);
     std::stringstream testss{};
-    qc.dump(testss, OpenQASM);
+    qc.dump(testss, qc::Format::OpenQASM);
     std::cout << testss.str() << std::endl;
     qc.reset();
-    qc.import(testss, OpenQASM);
+    qc.import(testss, qc::Format::OpenQASM);
     qc.print(std::cout);
     qc.stripIdleQubits();
     qc.print(std::cout);
@@ -314,7 +313,7 @@ TEST_F(QFRFunctionality, StripIdleAndDump) {
 }
 
 TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.i(0);
@@ -328,7 +327,7 @@ TEST_F(QFRFunctionality, CollapseCompoundOperationToStandard) {
 }
 
 TEST_F(QFRFunctionality, eliminateCompoundOperation) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.i(0);
     qc.i(0);
@@ -342,7 +341,7 @@ TEST_F(QFRFunctionality, eliminateCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.s(0);
     qc.sdag(0);
@@ -356,7 +355,7 @@ TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.phase(0, 1.);
     qc.phase(0, -1.);
@@ -369,7 +368,7 @@ TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.z(0);
     qc.measure(0, 0);
@@ -383,7 +382,7 @@ TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.z(0);
     qc.t(0);
@@ -399,7 +398,7 @@ TEST_F(QFRFunctionality, removeDiagonalCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.z(1, 0_pc);
     qc.measure({0, 1}, {0, 1});
@@ -413,7 +412,7 @@ TEST_F(QFRFunctionality, removeDiagonalTwoQubitGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.z(1, 0_pc);
     qc.x(0);
@@ -427,7 +426,7 @@ TEST_F(QFRFunctionality, leaveGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
-    const QubitCount   nqubits = 4;
+    const std::size_t  nqubits = 4;
     QuantumComputation qc(nqubits);
     qc.z(1, 0_pc);
     qc.x(0);
@@ -448,7 +447,7 @@ TEST_F(QFRFunctionality, removeComplexGateBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.x(0);
     qc.t(0);
@@ -463,7 +462,7 @@ TEST_F(QFRFunctionality, removeSimpleCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
-    const QubitCount   nqubits = 1;
+    const std::size_t  nqubits = 1;
     QuantumComputation qc(nqubits);
     qc.t(0);
     qc.x(0);
@@ -479,7 +478,7 @@ TEST_F(QFRFunctionality, removePartOfCompoundOpBeforeMeasure) {
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.swap(0, 1);
     std::cout << "-----------------------------" << std::endl;
@@ -510,7 +509,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsUndirectedArchitecture) {
     });
 }
 TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.swap(0, 1);
     std::cout << "-----------------------------" << std::endl;
@@ -566,7 +565,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsDirectedArchitecture) {
 }
 
 TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.swap(0, 1);
@@ -584,7 +583,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompound) {
     EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(it->get())->size(), 9);
 }
 TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.swap(0, 1);
@@ -603,7 +602,7 @@ TEST_F(QFRFunctionality, decomposeSWAPsCompoundDirected) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurements) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.h(0);
     qc.h(1);
@@ -631,7 +630,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurements) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     qc.h(0);
     qc.h(1);
@@ -658,7 +657,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsTwoQubitMeasurement) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.measure(0, 0);
@@ -684,7 +683,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompound) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.measure(0, 0);
@@ -711,7 +710,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundDegraded) {
 }
 
 TEST_F(QFRFunctionality, removeFinalMeasurementsCompoundEmpty) {
-    const QubitCount   nqubits = 2;
+    const std::size_t  nqubits = 2;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.measure(0, 0);
@@ -735,7 +734,7 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsWithOperationsInFront) {
     std::stringstream ss{};
     ss << circ;
     QuantumComputation qc{};
-    qc.import(ss, qc::OpenQASM);
+    qc.import(ss, qc::Format::OpenQASM);
     std::cout << "-----------------------------" << std::endl;
     qc.print(std::cout);
     CircuitOptimizer::removeFinalMeasurements(qc);
@@ -828,21 +827,21 @@ TEST_F(QFRFunctionality, gateShortCutsAndCloning) {
 }
 
 TEST_F(QFRFunctionality, cloningDifferentOperations) {
-    const QubitCount   nqubits = 5;
+    const std::size_t  nqubits = 5;
     QuantumComputation qc(nqubits);
     QuantumComputation comp(nqubits);
     comp.barrier(0);
     comp.h(0);
     qc.emplace_back(comp.asOperation());
     qc.classicControlled(qc::X, 0, qc.getCregs().at("c"), 1);
-    qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), std::vector<dd::Qubit>{0, 1}, 1);
+    qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(), std::vector<Qubit>{0, 1}, 1);
 
     auto qc_cloned = qc.clone();
     ASSERT_EQ(qc.size(), qc_cloned.size());
 }
 
 TEST_F(QFRFunctionality, wrongRegisterSizes) {
-    const QubitCount   nqubits = 5;
+    const std::size_t  nqubits = 5;
     QuantumComputation qc(nqubits);
     ASSERT_THROW(qc.measure({0}, {1, 2}), std::invalid_argument);
 }
@@ -1497,7 +1496,7 @@ TEST_F(QFRFunctionality, basicTensorDumpTest) {
     qc.x(0, 1_pc);
 
     std::stringstream ss{};
-    qc.dump(ss, qc::Tensor);
+    dd::dumpTensorNetwork(ss, qc);
 
     auto reference = "{\"tensors\": [\n"
                      "[[\"H   \", \"Q1\", \"GATE0\"], [\"q1_0\", \"q1_1\"], [2, 2], [[0.70710678118654757, 0], [0.70710678118654757, 0], [0.70710678118654757, 0], [-0.70710678118654757, 0]]],\n"
@@ -1514,7 +1513,7 @@ TEST_F(QFRFunctionality, compoundTensorDumpTest) {
     qc.emplace_back(comp.asOperation());
 
     std::stringstream ss{};
-    qc.dump(ss, qc::Tensor);
+    dd::dumpTensorNetwork(ss, qc);
 
     auto reference = "{\"tensors\": [\n"
                      "[[\"H   \", \"Q1\", \"GATE0\"], [\"q1_0\", \"q1_1\"], [2, 2], [[0.70710678118654757, 0], [0.70710678118654757, 0], [0.70710678118654757, 0], [-0.70710678118654757, 0]]],\n"
@@ -1528,17 +1527,17 @@ TEST_F(QFRFunctionality, errorTensorDumpTest) {
     qc.classicControlled(qc::X, 0, {0, 1U}, 1U);
 
     std::stringstream ss{};
-    EXPECT_THROW(qc.dump(ss, qc::Tensor), qc::QFRException);
+    EXPECT_THROW(dd::dumpTensorNetwork(ss, qc), qc::QFRException);
 
     ss.str("");
     qc.erase(qc.begin());
     qc.barrier(0);
     qc.measure(0, 0);
-    EXPECT_NO_THROW(qc.dump(ss, qc::Tensor));
+    EXPECT_NO_THROW(dd::dumpTensorNetwork(ss, qc));
 
     ss.str("");
     qc.reset(0);
-    EXPECT_THROW(qc.dump(ss, qc::Tensor), qc::QFRException);
+    EXPECT_THROW(dd::dumpTensorNetwork(ss, qc), qc::QFRException);
 }
 
 TEST_F(QFRFunctionality, trivialOperationReordering) {
@@ -1693,12 +1692,12 @@ TEST_F(QFRFunctionality, CNOTCancellation3) {
 
     CircuitOptimizer::cancelCNOTs(qc);
     EXPECT_TRUE(qc.size() == 2U);
-    auto& firstOperation = qc.front();
+    const auto& firstOperation = qc.front();
     EXPECT_EQ(firstOperation->getType(), qc::X);
     EXPECT_EQ(firstOperation->getTargets().front(), 0U);
     EXPECT_EQ(firstOperation->getControls().begin()->qubit, 1U);
 
-    auto& secondOperation = qc.back();
+    const auto& secondOperation = qc.back();
     EXPECT_EQ(secondOperation->getType(), qc::X);
     EXPECT_EQ(secondOperation->getTargets().front(), 1U);
     EXPECT_EQ(secondOperation->getControls().begin()->qubit, 0U);
@@ -1711,12 +1710,12 @@ TEST_F(QFRFunctionality, CNOTCancellation4) {
 
     CircuitOptimizer::cancelCNOTs(qc);
     EXPECT_TRUE(qc.size() == 2U);
-    auto& firstOperation = qc.front();
+    const auto& firstOperation = qc.front();
     EXPECT_EQ(firstOperation->getType(), qc::X);
     EXPECT_EQ(firstOperation->getTargets().front(), 1U);
     EXPECT_EQ(firstOperation->getControls().begin()->qubit, 0U);
 
-    auto& secondOperation = qc.back();
+    const auto& secondOperation = qc.back();
     EXPECT_EQ(secondOperation->getType(), qc::X);
     EXPECT_EQ(secondOperation->getTargets().front(), 0U);
     EXPECT_EQ(secondOperation->getControls().begin()->qubit, 1U);
@@ -1730,7 +1729,7 @@ TEST_F(QFRFunctionality, CNOTCancellation5) {
 
     CircuitOptimizer::cancelCNOTs(qc);
     EXPECT_TRUE(qc.size() == 1U);
-    auto& firstOperation = qc.front();
+    const auto& firstOperation = qc.front();
     EXPECT_EQ(firstOperation->getType(), qc::SWAP);
     EXPECT_EQ(firstOperation->getTargets().front(), 0U);
     EXPECT_EQ(firstOperation->getTargets().back(), 1U);
@@ -1768,7 +1767,7 @@ TEST_F(QFRFunctionality, ContainsLogicalQubit) {
 
 TEST_F(QFRFunctionality, AddAncillaryQubits) {
     QuantumComputation qc(1);
-    qc.addAncillaryQubit(1, -1);
+    qc.addAncillaryQubit(1, std::nullopt);
     EXPECT_EQ(qc.getNqubits(), 2);
     EXPECT_EQ(qc.getNancillae(), 1);
     ASSERT_EQ(qc.ancillary.size(), 2U);

--- a/test/unittests/test_symbolic.cpp
+++ b/test/unittests/test_symbolic.cpp
@@ -3,9 +3,7 @@
 #include "operations/SymbolicOperation.hpp"
 
 #include "gtest/gtest.h"
-#include <iostream>
 #include <memory>
-#include <sstream>
 
 using namespace qc;
 using namespace sym;

--- a/test/unittests/test_symbolic.cpp
+++ b/test/unittests/test_symbolic.cpp
@@ -1,6 +1,5 @@
 #include "Expression.hpp"
 #include "QuantumComputation.hpp"
-#include "dd/Definitions.hpp"
 #include "operations/SymbolicOperation.hpp"
 
 #include "gtest/gtest.h"
@@ -142,7 +141,7 @@ TEST_F(SymbolicTest, TestU3SymLambdaPhase) {
 }
 
 TEST_F(SymbolicTest, TestU3SymLambdaU2) {
-    symQc.u3(0, xMonom, 1.234, dd::PI_2);
+    symQc.u3(0, xMonom, 1.234, PI_2);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U2);
 }
 
@@ -152,7 +151,7 @@ TEST_F(SymbolicTest, TestU3SymLambdaU3) {
 }
 
 TEST_F(SymbolicTest, TestU3SymPhiU2) {
-    symQc.u3(0, 1.234, xMonom, dd::PI_2);
+    symQc.u3(0, 1.234, xMonom, PI_2);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U2);
 }
 
@@ -160,10 +159,10 @@ TEST_F(SymbolicTest, TestU3SymPhiU3) {
     symQc.u3(0, 0.0, xMonom, 4.567);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U3);
 
-    symQc.u3(0, dd::PI_2, xMonom, 1.234);
+    symQc.u3(0, PI_2, xMonom, 1.234);
     EXPECT_EQ((*(symQc.begin() + 1))->getType(), OpType::U3);
 
-    symQc.u3(0, dd::PI, xMonom, 3.465);
+    symQc.u3(0, PI, xMonom, 3.465);
     EXPECT_EQ((*(symQc.begin() + 2))->getType(), OpType::U3);
 
     symQc.u3(0, 1.2345, xMonom, 3.465);
@@ -174,10 +173,10 @@ TEST_F(SymbolicTest, TestU3SymThetaU3) {
     symQc.u3(0, 0.0, 0.0, xMonom);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U3);
 
-    symQc.u3(0, dd::PI_2, dd::PI_2, xMonom);
+    symQc.u3(0, PI_2, PI_2, xMonom);
     EXPECT_EQ((*(symQc.begin() + 1))->getType(), OpType::U3);
 
-    symQc.u3(0, dd::PI, 0.0, xMonom);
+    symQc.u3(0, PI, 0.0, xMonom);
     EXPECT_EQ((*(symQc.begin() + 2))->getType(), OpType::U3);
 
     symQc.u3(0, 1.234, 4.567, xMonom);
@@ -185,12 +184,12 @@ TEST_F(SymbolicTest, TestU3SymThetaU3) {
 }
 
 TEST_F(SymbolicTest, TestU3SymLambdaSymPhiU2) {
-    symQc.u3(0, xMonom, yMonom, dd::PI_2);
+    symQc.u3(0, xMonom, yMonom, PI_2);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U2);
 }
 
 TEST_F(SymbolicTest, TestU3SymLambdaSymPhiU3) {
-    symQc.u3(0, xMonom, yMonom, dd::PI_2 - 0.2);
+    symQc.u3(0, xMonom, yMonom, PI_2 - 0.2);
     EXPECT_EQ((*symQc.begin())->getType(), OpType::U3);
 }
 

--- a/test/unittests/test_symbolic.cpp
+++ b/test/unittests/test_symbolic.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <sstream>
 
-using namespace dd;
 using namespace qc;
 using namespace sym;
 class SymbolicTest: public ::testing::Test {

--- a/test/unittests/test_zx_functionality.cpp
+++ b/test/unittests/test_zx_functionality.cpp
@@ -7,15 +7,10 @@
 #include "QuantumComputation.hpp"
 #include "Simplify.hpp"
 #include "ZXDiagram.hpp"
-#include "dd/Control.hpp"
 #include "zx/FunctionalityConstruction.hpp"
 
 #include "gtest/gtest.h"
-#include <cstddef>
 #include <iostream>
-#include <sstream>
-
-using namespace dd::literals;
 
 class ZXDiagramTest: public ::testing::Test {
 public:
@@ -30,9 +25,9 @@ TEST_F(ZXDiagramTest, parse_qasm) {
        << "h q[0];"
        << "cx q[0],q[1];"
        << std::endl;
-    qc.import(ss, qc::OpenQASM);
+    qc.import(ss, qc::Format::OpenQASM);
     EXPECT_TRUE(zx::FunctionalityConstruction::transformableToZX(&qc));
-    zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc);
+    const zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc);
     EXPECT_EQ(diag.getNVertices(), 7);
     EXPECT_EQ(diag.getNEdges(), 6);
 
@@ -59,8 +54,9 @@ TEST_F(ZXDiagramTest, parse_qasm) {
     EXPECT_EQ(diag.getVData(2).value().type, zx::VertexType::Boundary);
     EXPECT_EQ(diag.getVData(3).value().type, zx::VertexType::Boundary);
 
-    for (std::size_t i = 0; i < diag.getNVertices(); i++)
+    for (std::size_t i = 0; i < diag.getNVertices(); i++) {
         EXPECT_TRUE(diag.getVData(i).value().phase.isZero());
+    }
 }
 
 TEST_F(ZXDiagramTest, complex_circuit) {
@@ -116,7 +112,7 @@ TEST_F(ZXDiagramTest, complex_circuit) {
        << "cx q[0],q[1];"
        << "h q[0];"
        << std::endl;
-    qc.import(ss, qc::OpenQASM);
+    qc.import(ss, qc::Format::OpenQASM);
 
     EXPECT_TRUE(zx::FunctionalityConstruction::transformableToZX(&qc));
     zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc);
@@ -129,6 +125,7 @@ TEST_F(ZXDiagramTest, complex_circuit) {
 }
 
 TEST_F(ZXDiagramTest, Phase) {
+    using namespace qc::literals;
     qc = qc::QuantumComputation(2);
     qc.phase(0, zx::PI / 4);
     qc.phase(0, 1_pc, zx::PI / 4);
@@ -152,7 +149,7 @@ TEST_F(ZXDiagramTest, Compound) {
        << "ccx q[0],q[1],q[2];"
        << std::endl;
 
-    qc.import(ss, qc::OpenQASM);
+    qc.import(ss, qc::Format::OpenQASM);
     EXPECT_TRUE(zx::FunctionalityConstruction::transformableToZX(&qc));
     zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc);
     zx::fullReduce(diag);
@@ -161,26 +158,29 @@ TEST_F(ZXDiagramTest, Compound) {
 }
 
 TEST_F(ZXDiagramTest, UnsupportedMultiControl) {
+    using namespace qc::literals;
     qc = qc::QuantumComputation(4);
     qc.x(0, {1_pc,
              2_pc,
              3_pc});
     EXPECT_FALSE(zx::FunctionalityConstruction::transformableToZX(&qc));
-    EXPECT_THROW(zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc), zx::ZXException);
+    EXPECT_THROW(const zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc), zx::ZXException);
 }
 
 TEST_F(ZXDiagramTest, UnsupportedControl) {
+    using namespace qc::literals;
     qc = qc::QuantumComputation(2);
     qc.y(0, 1_pc);
     EXPECT_FALSE(zx::FunctionalityConstruction::transformableToZX(&qc));
-    EXPECT_THROW(zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc), zx::ZXException);
+    EXPECT_THROW(const zx::ZXDiagram diag = zx::FunctionalityConstruction::buildFunctionality(&qc), zx::ZXException);
 }
 
 TEST_F(ZXDiagramTest, UnsupportedControl2) {
+    using namespace qc::literals;
     qc = qc::QuantumComputation(3);
     qc.y(0, {1_pc, 2_pc});
     EXPECT_FALSE(zx::FunctionalityConstruction::transformableToZX(&qc));
-    EXPECT_THROW(zx::ZXDiagram diag =
+    EXPECT_THROW(const zx::ZXDiagram diag =
                          zx::FunctionalityConstruction::buildFunctionality(&qc),
                  zx::ZXException);
 }
@@ -208,8 +208,8 @@ TEST_F(ZXDiagramTest, InitialLayout) {
 }
 
 TEST_F(ZXDiagramTest, FromSymbolic) {
-    sym::Variable x{"x"};
-    sym::Term     xTerm{1.0, x};
+    const sym::Variable x{"x"};
+    const sym::Term     xTerm{1.0, x};
     qc = qc::QuantumComputation{1};
     qc.rz(0, qc::Symbolic(xTerm));
     qc.rz(0, -qc::Symbolic(xTerm));
@@ -239,6 +239,7 @@ TEST_F(ZXDiagramTest, RZ) {
 }
 
 TEST_F(ZXDiagramTest, ISWAP) {
+    using namespace qc::literals;
     qc = qc::QuantumComputation(2);
     qc.iswap(0, 1);
 


### PR DESCRIPTION
This (long-overdue) PR makes the core features of the QFR independent of the DD package.
Most importantly, this lifts any limitations on the number of qubits that can be handled by the QFR itself and creates a cleaner separation of concerns.
Note that this required touching almost every part of the library, so the number of lines changed within this PR is quite massive.

These changes allow to separate the `dd` and the `zx` functionality into separate CMake targets, so that they are only built if necessary. This allows, e.g., QMAP to only link to the core library part not require the DD or the ZX part at all.
The new library targets are named `qfr_dd` and `qfr_zx` (with corresponding test targets `qfr_test_dd` and `qfr_test_zx`).

In addition to the above, a significant amount of linter warnings has been fixed while going through all the files. This should ease a future integration of `clang-tidy` considerably.

There are a few aspects that are expected to improve considerably on the way towards the envisioned `mqt-core` library:
- The core QFR library unconditionally links to the `ZX` package library as of now since some of the used structs (e.g. `Symbolic`) are only defined there. That dependency should be easy to resolve once both codebases are combined.
- There is a redundant specification of controls in the QFR (`qc::Control`) and the DD package (`dd::Control`) which merely exists because the DD package has no way of knowing about the higher level QFR Control class as of now. This redundancy (and the accompanying translation effort between both types at the interface between the QFR and the DD package) can be eliminated completely once both codebases are combined.
- Tests have been mainly kept as-is. However, it might make sense to re-consider some of them and re-organize the overall structure so that the tests also more closely following the idea of having a `core` library and several data-structure extensions (`dd` and `zx` for now)