### PR TITLE
🚸 Better DD package templating

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "extern/dd_package"]
         path = extern/dd_package
         url = https://github.com/cda-tum/dd_package.git
-        branch = main
+        branch = better-templating
         shallow = true
 [submodule "extern/json"]
         path = extern/json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "extern/dd_package"]
         path = extern/dd_package
         url = https://github.com/cda-tum/dd_package.git
-        branch = better-templating
+        branch = main
         shallow = true
 [submodule "extern/json"]
         path = extern/json

--- a/include/dd/FunctionalityConstruction.hpp
+++ b/include/dd/FunctionalityConstruction.hpp
@@ -13,8 +13,8 @@
 namespace dd {
     using namespace qc;
 
-    template<class DDPackage>
-    MatrixDD buildFunctionality(const QuantumComputation* qc, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    MatrixDD buildFunctionality(const QuantumComputation* qc, std::unique_ptr<dd::Package<Config>>& dd) {
         if (qc->getNqubits() == 0U) {
             return MatrixDD::one;
         }
@@ -43,8 +43,8 @@ namespace dd {
         return e;
     }
 
-    template<class DDPackage>
-    MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc, std::unique_ptr<dd::Package<Config>>& dd) {
         if (qc->getNqubits() == 0U) {
             return MatrixDD::one;
         }
@@ -75,8 +75,8 @@ namespace dd {
         return e;
     }
 
-    template<class DDPackage>
-    bool buildFunctionalityRecursive(const QuantumComputation* qc, std::size_t depth, std::size_t opIdx, std::stack<MatrixDD>& s, Permutation& permutation, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    bool buildFunctionalityRecursive(const QuantumComputation* qc, std::size_t depth, std::size_t opIdx, std::stack<MatrixDD>& s, Permutation& permutation, std::unique_ptr<dd::Package<Config>>& dd) {
         // base case
         if (depth == 1U) {
             auto e = getDD(qc->at(opIdx).get(), dd, permutation);
@@ -117,8 +117,8 @@ namespace dd {
         return success;
     }
 
-    template<class DDPackage>
-    MatrixDD buildFunctionality(const qc::Grover* qc, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    MatrixDD buildFunctionality(const qc::Grover* qc, std::unique_ptr<dd::Package<Config>>& dd) {
         QuantumComputation groverIteration(qc->getNqubits());
         qc->oracle(groverIteration);
         qc->diffusion(groverIteration);
@@ -149,8 +149,8 @@ namespace dd {
         return e;
     }
 
-    template<class DDPackage>
-    MatrixDD buildFunctionalityRecursive(const qc::Grover* qc, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    MatrixDD buildFunctionalityRecursive(const qc::Grover* qc, std::unique_ptr<dd::Package<Config>>& dd) {
         QuantumComputation groverIteration(qc->getNqubits());
         qc->oracle(groverIteration);
         qc->diffusion(groverIteration);

--- a/include/dd/NoiseFunctionality.hpp
+++ b/include/dd/NoiseFunctionality.hpp
@@ -28,15 +28,15 @@ namespace dd {
         identity
     };
 
-    template<class DDPackage>
+    template<class Config>
     class StochasticNoiseFunctionality {
     public:
-        StochasticNoiseFunctionality(const std::unique_ptr<DDPackage>& package,
-                                     dd::QubitCount                    nQubits,
-                                     double                            gateNoiseProbability,
-                                     double                            amplitudeDampingProb,
-                                     double                            multiQubitGateFactor,
-                                     std::vector<dd::NoiseOperations>  noiseEffects):
+        StochasticNoiseFunctionality(const std::unique_ptr<dd::Package<Config>>& package,
+                                     dd::QubitCount                              nQubits,
+                                     double                                      gateNoiseProbability,
+                                     double                                      amplitudeDampingProb,
+                                     double                                      multiQubitGateFactor,
+                                     std::vector<dd::NoiseOperations>            noiseEffects):
             package(package),
             nQubits(nQubits),
             dist(0.0, 1.0L),
@@ -60,9 +60,9 @@ namespace dd {
         }
 
     protected:
-        const std::unique_ptr<DDPackage>&      package;
-        const dd::QubitCount                   nQubits;
-        std::uniform_real_distribution<dd::fp> dist;
+        const std::unique_ptr<dd::Package<Config>>& package;
+        const dd::QubitCount                        nQubits;
+        std::uniform_real_distribution<dd::fp>      dist;
 
         const double                     noiseProbability;
         const double                     noiseProbabilityMulti;
@@ -211,18 +211,18 @@ namespace dd {
         }
     };
 
-    template<class DDPackage>
+    template<class Config>
     class DeterministicNoiseFunctionality {
     public:
-        DeterministicNoiseFunctionality(const std::unique_ptr<DDPackage>& package,
-                                        dd::QubitCount                    nQubits,
-                                        double                            noiseProbSingleQubit,
-                                        double                            noiseProbMultiQubit,
-                                        double                            ampDampingProbSingleQubit,
-                                        double                            ampDampingProbMultiQubit,
-                                        std::vector<dd::NoiseOperations>  noiseEffects,
-                                        bool                              useDensityMatrixType,
-                                        bool                              sequentiallyApplyNoise):
+        DeterministicNoiseFunctionality(const std::unique_ptr<dd::Package<Config>>& package,
+                                        dd::QubitCount                              nQubits,
+                                        double                                      noiseProbSingleQubit,
+                                        double                                      noiseProbMultiQubit,
+                                        double                                      ampDampingProbSingleQubit,
+                                        double                                      ampDampingProbMultiQubit,
+                                        std::vector<dd::NoiseOperations>            noiseEffects,
+                                        bool                                        useDensityMatrixType,
+                                        bool                                        sequentiallyApplyNoise):
             package(package),
             nQubits(nQubits),
             noiseProbSingleQubit(noiseProbSingleQubit),
@@ -235,8 +235,8 @@ namespace dd {
         }
 
     protected:
-        const std::unique_ptr<DDPackage>& package;
-        const dd::QubitCount              nQubits;
+        const std::unique_ptr<dd::Package<Config>>& package;
+        const dd::QubitCount                        nQubits;
 
         const double noiseProbSingleQubit;
         const double noiseProbMultiQubit;

--- a/include/dd/Operations.hpp
+++ b/include/dd/Operations.hpp
@@ -23,8 +23,8 @@ namespace qc {
 
 namespace dd {
     // single-target Operations
-    template<class DDPackage>
-    qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op, std::unique_ptr<DDPackage>& dd, const dd::Controls& controls, dd::Qubit target, bool inverse) {
+    template<class Config>
+    qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op, std::unique_ptr<dd::Package<Config>>& dd, const dd::Controls& controls, dd::Qubit target, bool inverse) {
         GateMatrix gm;
 
         const auto  type       = op->getType();
@@ -73,8 +73,8 @@ namespace dd {
     }
 
     // two-target Operations
-    template<class DDPackage>
-    qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op, std::unique_ptr<DDPackage>& dd, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, bool inverse) {
+    template<class Config>
+    qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op, std::unique_ptr<dd::Package<Config>>& dd, const dd::Controls& controls, dd::Qubit target0, dd::Qubit target1, bool inverse) {
         const auto type       = op->getType();
         const auto nqubits    = op->getNqubits();
         const auto startQubit = op->getStartingQubit();
@@ -111,17 +111,17 @@ namespace dd {
     //      if perm[0] = 1 and perm[1] = 0
     //      then cx 0 1 will be translated to cx perm[0] perm[1] == cx 1 0
 
-    template<class DDPackage>
-    qc::MatrixDD getDD(const qc::Operation* op, std::unique_ptr<DDPackage>& dd, qc::Permutation& permutation, bool inverse = false) {
+    template<class Config>
+    qc::MatrixDD getDD(const qc::Operation* op, std::unique_ptr<dd::Package<Config>>& dd, qc::Permutation& permutation, bool inverse = false) {
         const auto type    = op->getType();
         const auto nqubits = op->getNqubits();
 
         // check whether the operation can be handled by the underlying DD package
-        if (nqubits > DDPackage::MAX_POSSIBLE_QUBITS) {
+        if (nqubits > dd::Package<Config>::MAX_POSSIBLE_QUBITS) {
             throw qc::QFRException("Requested too many qubits to be handled by the DD package. Qubit datatype only allows up to " +
-                                   std::to_string(DDPackage::MAX_POSSIBLE_QUBITS) + " qubits, while " +
+                                   std::to_string(dd::Package<Config>::MAX_POSSIBLE_QUBITS) + " qubits, while " +
                                    std::to_string(nqubits) + " were requested. If you want to use more than " +
-                                   std::to_string(DDPackage::MAX_POSSIBLE_QUBITS) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
+                                   std::to_string(dd::Package<Config>::MAX_POSSIBLE_QUBITS) + " qubits, you have to recompile the package with a wider Qubit type in `export/dd_package/include/dd/Definitions.hpp!`");
         }
 
         // if a permutation is provided and the current operation is a SWAP, this routine just updates the permutation
@@ -191,24 +191,24 @@ namespace dd {
         throw qc::QFRException("DD for non-unitary operation not available!");
     }
 
-    template<class DDPackage>
-    qc::MatrixDD getDD(const qc::Operation* op, std::unique_ptr<DDPackage>& dd, bool inverse = false) {
+    template<class Config>
+    qc::MatrixDD getDD(const qc::Operation* op, std::unique_ptr<dd::Package<Config>>& dd, bool inverse = false) {
         qc::Permutation perm{};
         return getDD(op, dd, perm, inverse);
     }
 
-    template<class DDPackage>
-    qc::MatrixDD getInverseDD(const qc::Operation* op, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    qc::MatrixDD getInverseDD(const qc::Operation* op, std::unique_ptr<dd::Package<Config>>& dd) {
         return getDD(op, dd, true);
     }
 
-    template<class DDPackage>
-    qc::MatrixDD getInverseDD(const qc::Operation* op, std::unique_ptr<DDPackage>& dd, qc::Permutation& permutation) {
+    template<class Config>
+    qc::MatrixDD getInverseDD(const qc::Operation* op, std::unique_ptr<dd::Package<Config>>& dd, qc::Permutation& permutation) {
         return getDD(op, dd, permutation, true);
     }
 
-    template<class DDPackage>
-    void dumpTensor(qc::Operation* op, std::ostream& of, std::vector<std::size_t>& inds, std::size_t& gateIdx, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    void dumpTensor(qc::Operation* op, std::ostream& of, std::vector<std::size_t>& inds, std::size_t& gateIdx, std::unique_ptr<dd::Package<Config>>& dd) {
         const auto type = op->getType();
         if (op->isStandardOperation()) {
             auto        nqubits  = op->getNqubits();
@@ -338,8 +338,8 @@ namespace dd {
 
     // apply swaps 'on' DD in order to change 'from' to 'to'
     // where |from| >= |to|
-    template<class DDType, class DDPackage>
-    void changePermutation(DDType& on, qc::Permutation& from, const qc::Permutation& to, std::unique_ptr<DDPackage>& dd, bool regular = true) {
+    template<class DDType, class Config>
+    void changePermutation(DDType& on, qc::Permutation& from, const qc::Permutation& to, std::unique_ptr<dd::Package<Config>>& dd, bool regular = true) {
         assert(from.size() >= to.size());
 
         // iterate over (k,v) pairs of second permutation

--- a/include/dd/Simulation.hpp
+++ b/include/dd/Simulation.hpp
@@ -12,8 +12,8 @@
 namespace dd {
     using namespace qc;
 
-    template<class DDPackage>
-    VectorDD simulate(const QuantumComputation* qc, const VectorDD& in, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    VectorDD simulate(const QuantumComputation* qc, const VectorDD& in, std::unique_ptr<dd::Package<Config>>& dd) {
         // measurements are currently not supported here
         auto permutation = qc->initialLayout;
         auto e           = in;
@@ -35,8 +35,8 @@ namespace dd {
         return e;
     }
 
-    template<class DDPackage>
-    std::map<std::string, std::size_t> simulate(const QuantumComputation* qc, const VectorDD& in, std::unique_ptr<DDPackage>& dd, std::size_t shots, std::size_t seed = 0U) {
+    template<class Config>
+    std::map<std::string, std::size_t> simulate(const QuantumComputation* qc, const VectorDD& in, std::unique_ptr<dd::Package<Config>>& dd, std::size_t shots, std::size_t seed = 0U) {
         bool isDynamicCircuit = false;
         bool hasMeasurements  = false;
         bool measurementsLast = true;
@@ -217,15 +217,15 @@ namespace dd {
         }
     }
 
-    template<class DDPackage>
-    void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in, dd::ProbabilityVector& probVector, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in, dd::ProbabilityVector& probVector, std::unique_ptr<dd::Package<Config>>& dd) {
         // ! initial layout, output permutation and garbage qubits are currently not supported here
         dd->incRef(in);
         extractProbabilityVectorRecursive(qc, in, qc->begin(), std::map<std::size_t, char>{}, 1., probVector, dd);
     }
 
-    template<class DDPackage>
-    void extractProbabilityVectorRecursive(const QuantumComputation* qc, const VectorDD& currentState, decltype(qc->begin()) currentIt, std::map<std::size_t, char> measurements, dd::fp commonFactor, dd::ProbabilityVector& probVector, std::unique_ptr<DDPackage>& dd) {
+    template<class Config>
+    void extractProbabilityVectorRecursive(const QuantumComputation* qc, const VectorDD& currentState, decltype(qc->begin()) currentIt, std::map<std::size_t, char> measurements, dd::fp commonFactor, dd::ProbabilityVector& probVector, std::unique_ptr<dd::Package<Config>>& dd) {
         auto state = currentState;
         for (auto it = currentIt; it != qc->end(); ++it) {
             auto& op = (*it);
@@ -399,8 +399,8 @@ namespace dd {
         }
     }
 
-    template<class DDPackage>
-    VectorDD simulate(GoogleRandomCircuitSampling* qc, const VectorDD& in, std::unique_ptr<DDPackage>& dd, short ncycles = -1) {
+    template<class Config>
+    VectorDD simulate(GoogleRandomCircuitSampling* qc, const VectorDD& in, std::unique_ptr<dd::Package<Config>>& dd, short ncycles = -1) {
         if (ncycles != -1 && (static_cast<std::size_t>(ncycles) < qc->cycles.size() - 2U)) {
             qc->removeCycles(qc->cycles.size() - 2U - ncycles);
         }

--- a/test/unittests/test_dd_noise_functionality.cpp
+++ b/test/unittests/test_dd_noise_functionality.cpp
@@ -16,25 +16,7 @@ struct StochasticNoiseSimulatorDDPackageConfig: public dd::DDPackageConfig {
     static constexpr std::size_t STOCHASTIC_CACHE_OPS = qc::OpType::OpCount;
 };
 
-using StochasticNoiseTestPackage = dd::Package<StochasticNoiseSimulatorDDPackageConfig::UT_VEC_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                               StochasticNoiseSimulatorDDPackageConfig::UT_MAT_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_VEC_ADD_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_ADD_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_TRANS_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_VEC_KRON_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_MAT_KRON_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_DM_NOISE_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::UT_DM_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_DM_DM_MULT_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::CT_DM_ADD_NBUCKET,
-                                               StochasticNoiseSimulatorDDPackageConfig::STOCHASTIC_CACHE_OPS>;
+using StochasticNoiseTestPackage = dd::Package<StochasticNoiseSimulatorDDPackageConfig>;
 
 struct DensityMatrixSimulatorDDPackageConfig: public dd::DDPackageConfig {
     static constexpr std::size_t UT_DM_NBUCKET                 = 65536U;
@@ -61,25 +43,7 @@ struct DensityMatrixSimulatorDDPackageConfig: public dd::DDPackageConfig {
     static constexpr std::size_t STOCHASTIC_CACHE_OPS           = 1U;
 };
 
-using DensityMatrixTestPackage = dd::Package<DensityMatrixSimulatorDDPackageConfig::UT_VEC_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::UT_VEC_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfig::UT_MAT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::UT_MAT_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_VEC_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_TRANS_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_CONJ_TRANS_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_VEC_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_MAT_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_VEC_KRON_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_MAT_KRON_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_VEC_INNER_PROD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_DM_NOISE_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::UT_DM_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::UT_DM_INITIAL_ALLOCATION_SIZE,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_DM_DM_MULT_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::CT_DM_ADD_NBUCKET,
-                                             DensityMatrixSimulatorDDPackageConfig::STOCHASTIC_CACHE_OPS>;
+using DensityMatrixTestPackage = dd::Package<DensityMatrixSimulatorDDPackageConfig>;
 
 class DDNoiseFunctionalityTest: public ::testing::Test {
 protected:
@@ -128,7 +92,7 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPDApplySequential) {
 
     const auto noiseEffects = {dd::amplitudeDamping, dd::phaseFlip, dd::depolarization, dd::identity};
 
-    auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality<DensityMatrixTestPackage>(
+    auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality(
             dd,
             qc.getNqubits(),
             0.01,
@@ -174,7 +138,7 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
 
     const auto noiseEffects = {dd::amplitudeDamping, dd::identity, dd::phaseFlip, dd::depolarization};
 
-    auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality<DensityMatrixTestPackage>(
+    auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality(
             dd,
             qc.getNqubits(),
             0.01,
@@ -233,7 +197,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4TrackAPD) {
 
     const auto noiseEffects = {dd::amplitudeDamping, dd::phaseFlip, dd::identity, dd::depolarization};
 
-    auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality<StochasticNoiseTestPackage>(
+    auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
             dd,
             qc.getNqubits(),
             0.01,
@@ -300,7 +264,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4IdentiyError) {
 
     const auto noiseEffects = {dd::identity};
 
-    auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality<StochasticNoiseTestPackage>(
+    auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
             dd,
             qc.getNqubits(),
             0.01,


### PR DESCRIPTION
This PR builds on https://github.com/cda-tum/dd_package/pull/127 and refactors the DD template code.
None of the changes actually affect the performance or functionality of the code, but drastically improve IDE support.