### PR TITLE
🚸 Add barrier before measurements

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -924,7 +924,11 @@ namespace qc {
                 cregs[registerName].second = outputPermutation.size();
             }
         }
-
+        auto targets = std::vector<qc::Qubit>{};
+        for (std::size_t q = 0; q < getNqubits(); ++q) {
+            targets.emplace_back(q);
+        }
+        barrier(targets);
         // append measurements according to output permutation
         for (const auto& [qubit, clbit]: outputPermutation) {
             measure(qubit, clbit);

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -457,6 +457,7 @@ TEST_F(IO, appendMeasurementsAccordingToOutputPermutationAugmentRegister) {
                  "creg c[2];\n"
                  "x q[0];\n"
                  "x q[1];\n"
+                 "barrier q;\n"
                  "measure q[0] -> c[0];\n"
                  "measure q[1] -> c[1];\n");
 }
@@ -501,6 +502,7 @@ TEST_F(IO, appendMeasurementsAccordingToOutputPermutationAddRegister) {
                  "creg c[1];\n"
                  "x q[0];\n"
                  "x q[1];\n"
+                 "barrier q;\n"
                  "measure q[0] -> d[0];\n"
                  "measure q[1] -> c[0];\n");
 }


### PR DESCRIPTION
This tiny little PR adds a barrier statement before adding measurements to the end of a circuit according to the output permutation. This allows for prettier printing and is more in line with what Qiskit is doing in the `measure_all` method.