### PR TITLE
🐛 Fix controlled u-gate OpenQASM output

### DIFF
--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -267,16 +267,16 @@ namespace qc {
                 }
                 break;
             case V:
-                op << "u(pi/2, -pi/2, pi/2)";
+                op << "u3(pi/2, -pi/2, pi/2)";
                 break;
             case Vdag:
-                op << "u(pi/2, pi/2, -pi/2)";
+                op << "u3(pi/2, pi/2, -pi/2)";
                 break;
             case U3:
-                op << "u(" << parameter[2] << "," << parameter[1] << "," << parameter[0] << ")";
+                op << "u3(" << parameter[2] << "," << parameter[1] << "," << parameter[0] << ")";
                 break;
             case U2:
-                op << "u(pi/2, " << parameter[1] << "," << parameter[0] << ")";
+                op << "u3(pi/2, " << parameter[1] << "," << parameter[0] << ")";
                 break;
             case Phase:
                 op << "p(" << parameter[0] << ")";


### PR DESCRIPTION
The qelib1.inc file from OpenQASM contains the functions u3, cu3, u and cu (https://github.com/Qiskit/qiskit-terra/blob/main/qiskit/qasm/libs/qelib1.inc). For this particular case, it is important to explicitly use the 3 parameter version, because cu has 4 parameters, while u only has 3 parameters.
So prepending c to the regular u gate leads to incorrect OpenQASM code, because then one parameter is missing (gamma).

