### PR TITLE
🩹 Fix strip idle qubits corner case

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -709,6 +709,19 @@ namespace qc {
                 }
 
                 auto logicalQubitIndex = initialLayout.at(physicalQubitIndex);
+                // check whether the logical qubit is used in the output permutation
+                bool usedInOutputPermutation = false;
+                for (const auto& [physical, logical]: outputPermutation) {
+                    if (logical == logicalQubitIndex) {
+                        usedInOutputPermutation = true;
+                        break;
+                    }
+                }
+                if (usedInOutputPermutation) {
+                    // cannot strip a logical qubit that is used in the output permutation
+                    continue;
+                }
+
                 removeQubit(logicalQubitIndex);
 
                 if (reduceIOpermutations && (logicalQubitIndex < nqubits + nancillae)) {

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -726,9 +726,6 @@ namespace qc {
                 }
             }
         }
-        for (auto& op: ops) {
-            op->setNqubits(nqubits + nancillae);
-        }
     }
 
     std::string QuantumComputation::getQubitRegister(const Qubit physicalQubitIndex) const {

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -712,15 +712,15 @@ namespace qc {
                 removeQubit(logicalQubitIndex);
 
                 if (reduceIOpermutations && (logicalQubitIndex < nqubits + nancillae)) {
-                    for (auto& q: initialLayout) {
-                        if (q.second > logicalQubitIndex) {
-                            --q.second;
+                    for (auto& [physical, logical]: initialLayout) {
+                        if (logical > logicalQubitIndex) {
+                            --logical;
                         }
                     }
 
-                    for (auto& q: outputPermutation) {
-                        if (q.second > logicalQubitIndex) {
-                            --q.second;
+                    for (auto& [physical, logical]: outputPermutation) {
+                        if (logical > logicalQubitIndex) {
+                            --logical;
                         }
                     }
                 }

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1717,3 +1717,13 @@ TEST_F(QFRFunctionality, CircuitToOperation) {
     EXPECT_EQ(op2->getNqubits(), 2U);
     EXPECT_TRUE(qc.empty());
 }
+
+TEST_F(QFRFunctionality, AvoidStrippingIdleQubitWhenInOutputPermutation) {
+    // a qubit being present in the output permutation should not be stripped
+    QuantumComputation qc(2);
+    qc.measure(1, 0);
+    qc.initializeIOMapping();
+    qc.stripIdleQubits();
+    EXPECT_EQ(qc.getNqubits(), 2U);
+    EXPECT_EQ(qc.outputPermutation[1], 0U);
+}


### PR DESCRIPTION
This PR fixes a small corner case that was overlooked when stripping idle qubits.
An idle qubit must not be removed from the circuit if the logical qubit is part of the output permutation.