### PR TITLE
🩹 Allow removing logical qubits used in the output permutation by force

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -717,7 +717,7 @@ namespace qc {
                         break;
                     }
                 }
-                if (usedInOutputPermutation) {
+                if (usedInOutputPermutation && !force) {
                     // cannot strip a logical qubit that is used in the output permutation
                     continue;
                 }


### PR DESCRIPTION
This is a quick fix that resolves the failures observed in the recent QMAP update. It allows to strip idle qubits from a circuit even if they are used in the output permutation, whenever the `force` flag is set.