### PR TITLE
♻️ Refactor global phase handling

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -52,6 +52,8 @@ namespace qc {
         std::mt19937_64 mt;
         std::size_t     seed = 0;
 
+        fp globalPhase = 0.;
+
         std::unordered_set<sym::Variable> occuringVariables;
 
         void importOpenQASM(std::istream& is);
@@ -223,6 +225,7 @@ namespace qc {
             qc.seed              = seed;
             qc.mt                = mt;
             qc.occuringVariables = occuringVariables;
+            qc.globalPhase       = globalPhase;
 
             for (auto const& op: ops) {
                 qc.ops.emplace_back<>(op->clone());
@@ -240,6 +243,7 @@ namespace qc {
         [[nodiscard]] const ClassicalRegisterMap& getCregs() const { return cregs; }
         [[nodiscard]] const QuantumRegisterMap&   getANCregs() const { return ancregs; }
         [[nodiscard]] decltype(mt)&               getGenerator() { return mt; }
+        [[nodiscard]] fp                          getGlobalPhase() { return globalPhase; }
 
         void setName(const std::string& n) { name = n; }
 
@@ -281,7 +285,14 @@ namespace qc {
         /// Adds a global phase to the quantum circuit.
         /// \param angle the angle to add
         void gphase(const fp& angle) {
-            emplace_back<StandardOperation>(getNqubits(), Controls{}, Targets{}, qc::GPhase, std::vector{angle});
+            globalPhase += angle;
+            // normalize to [0, 2pi)
+            while (globalPhase < 0) {
+                globalPhase += 2 * PI;
+            }
+            while (globalPhase >= 2 * PI) {
+                globalPhase -= 2 * PI;
+            }
         }
 
         void i(const Qubit target) {

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -243,7 +243,8 @@ namespace qc {
         [[nodiscard]] const ClassicalRegisterMap& getCregs() const { return cregs; }
         [[nodiscard]] const QuantumRegisterMap&   getANCregs() const { return ancregs; }
         [[nodiscard]] decltype(mt)&               getGenerator() { return mt; }
-        [[nodiscard]] fp                          getGlobalPhase() { return globalPhase; }
+
+        [[nodiscard]] fp getGlobalPhase() const { return globalPhase; }
 
         void setName(const std::string& n) { name = n; }
 

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1843,3 +1843,12 @@ TEST_F(QFRFunctionality, U3SpecialCases) {
     EXPECT_EQ(qc.at(5)->getParameter().at(1), 0.25);
     EXPECT_EQ(qc.at(5)->getParameter().at(2), 0.125);
 }
+
+TEST_F(QFRFunctionality, GlobalPhaseNormalization) {
+    QuantumComputation qc(1);
+    EXPECT_EQ(qc.getGlobalPhase(), 0.);
+    qc.gphase(-PI);
+    EXPECT_EQ(qc.getGlobalPhase(), PI);
+    qc.gphase(PI);
+    EXPECT_EQ(qc.getGlobalPhase(), 0.);
+}

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -773,6 +773,7 @@ TEST_F(QFRFunctionality, gateShortCutsAndCloning) {
 
     auto qcCloned = qc.clone();
     ASSERT_EQ(qc.size(), qcCloned.size());
+    ASSERT_EQ(qcCloned.getGlobalPhase(), PI);
 }
 
 TEST_F(QFRFunctionality, cloningDifferentOperations) {


### PR DESCRIPTION
This PR introduces a `globalPhase` member in the QuantumComputation class that tracks the circuit's global phase.
Instead of appending an operation, the `qc.gphase(theta)` function now just adds to (and normalises) the phase of the circuit.
Previously, the Qiskit Circuit import would add an additional gate to every circuit. This already led to some problems in QMAP and is now resolved in a cleaner fashion, by just tracking the global phase.