### PR TITLE
Add opaque teleportation gate

### DIFF
--- a/include/parsers/qasm_parser/Parser.hpp
+++ b/include/parsers/qasm_parser/Parser.hpp
@@ -143,6 +143,7 @@ namespace qasm {
                 {"u3", {0, 1, 3, qc::U3}},
                 {"U", {0, 1, 3, qc::U3}},
                 {"u", {0, 1, 3, qc::U3}},
+                {"teleport", {0, 3, 0, qc::Teleportation}},
                 {"swap", {0, 2, 0, qc::SWAP}},
                 {"iswap", {0, 2, 0, qc::iSWAP}},
                 {"cnot", {1, 1, 0, qc::X}},

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -632,7 +632,7 @@ namespace qc {
 
         of << "OPENQASM 2.0;" << std::endl;
         of << "include \"qelib1.inc\";" << std::endl;
-        if (std::any_of(std::begin(ops), std::end(ops), [](const auto& op){return op->getType() == OpType::Teleportation;})) {
+        if (std::any_of(std::begin(ops), std::end(ops), [](const auto& op) { return op->getType() == OpType::Teleportation; })) {
             of << "opaque teleport src, anc, tgt;" << std::endl;
         }
         if (!qregs.empty()) {

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -632,6 +632,9 @@ namespace qc {
 
         of << "OPENQASM 2.0;" << std::endl;
         of << "include \"qelib1.inc\";" << std::endl;
+        if (std::any_of(std::begin(ops), std::end(ops), [](const auto& op){return op->getType() == OpType::Teleportation;})) {
+            of << "opaque teleport src, anc, tgt;" << std::endl;
+        }
         if (!qregs.empty()) {
             printSortedRegisters(qregs, "qreg", of);
         } else if (nqubits > 0) {

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1871,7 +1871,7 @@ TEST_F(QFRFunctionality, OpNameToTypeSimple) {
 
 TEST_F(QFRFunctionality, dumpAndImportTeleportation) {
     QuantumComputation qc(3);
-    qc.emplace_back<StandardOperation>(3, Targets{0,1,2}, OpType::Teleportation);
+    qc.emplace_back<StandardOperation>(3, Targets{0, 1, 2}, OpType::Teleportation);
     std::stringstream ss;
     qc.dumpOpenQASM(ss);
     EXPECT_TRUE(ss.str().find("teleport") != std::string::npos);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1868,3 +1868,16 @@ TEST_F(QFRFunctionality, OpNameToTypeSimple) {
 
     EXPECT_THROW([[maybe_unused]] const auto type = qc::opTypeFromString("foo"), std::invalid_argument);
 }
+
+TEST_F(QFRFunctionality, dumpAndImportTeleportation) {
+    QuantumComputation qc(3);
+    qc.emplace_back<StandardOperation>(3, Targets{0,1,2}, OpType::Teleportation);
+    std::stringstream ss;
+    qc.dumpOpenQASM(ss);
+    EXPECT_TRUE(ss.str().find("teleport") != std::string::npos);
+
+    QuantumComputation qcImported(3);
+    qcImported.import(ss, qc::Format::OpenQASM);
+    ASSERT_EQ(qcImported.size(), 1);
+    EXPECT_EQ(qcImported.at(0)->getType(), OpType::Teleportation);
+}


### PR DESCRIPTION
If teleportation was used in mapping, add an opaque gate to the output.