### PR TITLE
👷⚡ speed up CI with independent coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,21 @@ jobs:
         run: cmake --build build --config Release
       - name: Test
         run: ctest -C Release --output-on-failure --test-dir build --repeat until-pass:3 --timeout 300
-      - if: runner.os == 'Linux'
-        name: Coverage
-        run: |
-          cmake -S . -B buildCov -DCMAKE_BUILD_TYPE=Debug -DBUILD_QFR_TESTS=ON -DENABLE_COVERAGE=ON
-          cmake --build buildCov --config Debug
-          ctest -C Debug --output-on-failure --test-dir buildCov --repeat until-pass:3 --timeout 300
 
-      - if: runner.os == 'Linux'
-        name: Upload coverage to Codecov
+  coverage:
+    name: C++ Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_QFR_TESTS=ON -DENABLE_COVERAGE=ON
+      - name: Build
+        run: cmake --build build --config Debug
+      - name: Test
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 300
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This tiny PR speeds up the CI by creating an independent job for collecting coverage instead of waiting for the linux build to finish.