### PR TITLE
👨‍💻 introduce compiler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "${{matrix.config.os}}"
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_QFR_TESTS=ON ${{ matrix.config.toolchain }}
       - name: Build
@@ -47,6 +51,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "coverage"
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_QFR_TESTS=ON -DENABLE_COVERAGE=ON
       - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "CodeQL-${{ matrix.language }}"
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(cmake/StandardProjectSettings.cmake)
 include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/CheckSubmodule.cmake)
 include(cmake/PackageAddTest.cmake)
+include(cmake/Cache.cmake)
 
 if(NOT TARGET project_warnings)
   # Use the warnings specified in CompilerWarnings.cmake

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -1,0 +1,24 @@
+option(ENABLE_CACHE "Enable compiler cache if available" ON)
+if(NOT ENABLE_CACHE)
+  return()
+endif()
+
+set(CACHE_OPTION_VALUES "ccache" "sccache")
+set(CACHE_OPTION
+    "ccache"
+    CACHE STRING "Compiler cache to use")
+set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
+list(FIND CACHE_OPTION_VALUES ${CACHE_OPTION} CACHE_OPTION_INDEX)
+if(CACHE_OPTION_INDEX EQUAL -1)
+  message(NOTICE
+          "Unknown compiler cache '${CACHE_OPTION}'. Available options are: ${CACHE_OPTION_VALUES}")
+endif()
+
+find_program(CACHE_BINARY ${CACHE_OPTION})
+if(CACHE_BINARY)
+  message(STATUS "Compiler cache '${CACHE_OPTION}' found and enabled")
+  set(CMAKE_C_COMPILER_LAUNCHER ${CACHE_BINARY})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CACHE_BINARY})
+else()
+  message(NOTICE "${CACHE_OPTION} is enabled but was not found. Not using it")
+endif()


### PR DESCRIPTION
This PR enables `ccache` integration for fast local as well as CI development.

Note: Caching under Windows does not yet work and will be investigated at a later point in time.

Thanks @marcelwa for the hint and the initial work towards setting this up in fiction 🙏🏼 