### PR TITLE
👨‍💻 introduce `mold` as default linker under Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "${{matrix.config.os}}"
+      - name: Set up mold as linker (Linux only)
+        uses: rui314/setup-mold@v1
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_QFR_TESTS=ON ${{ matrix.config.toolchain }}
       - name: Build
@@ -55,6 +57,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "coverage"
+      - name: Set up mold as linker
+        uses: rui314/setup-mold@v1
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_QFR_TESTS=ON -DENABLE_COVERAGE=ON
       - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           key: "CodeQL-${{ matrix.language }}"
 
+      - name: Set up mold as linker
+        uses: rui314/setup-mold@v1
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
This PR introduces [the `mold` linker](https://github.com/rui314/mold) as the default linker for Linux CI builds.
This should speed up the respective CI builds.

Thanks again to @marcelwa for the hint!