### PR TITLE
Actually Populate the Params list from Qobjs

### DIFF
--- a/mqt/qfr/qiskit/QasmQobjExperiment.hpp
+++ b/mqt/qfr/qiskit/QasmQobjExperiment.hpp
@@ -71,6 +71,9 @@ namespace qc::qiskit {
             } else if (NATIVELY_SUPPORTED_GATES.count(instructionName) != 0) {
                 auto&&   qubits = instruction.attr("qubits").cast<py::list>();
                 py::list params{};
+                if (py::hasattr(instruction, "params")) {
+                    params = instruction.attr("params");
+                }
                 // natively supported operations
                 if (instructionName == "i" || instructionName == "id" || instructionName == "iden") {
                     addOperation(qc, I, qubits, params);


### PR DESCRIPTION
This PR fixes a bug where the parameters of parameterized gates are not saved when reading in circuits from `QasmQobjExperiments`. Previously the `params` list was always empty.

Related:

- cda-tum/ddsim#190
- cda-tum/ddsim#248